### PR TITLE
Added overload to support custom frame.

### DIFF
--- a/iphone/ZXingWidget/Classes/ZXingWidgetController.h
+++ b/iphone/ZXingWidget/Classes/ZXingWidgetController.h
@@ -63,6 +63,7 @@
 
 - (id)initWithDelegate:(id<ZXingDelegate>)delegate showCancel:(BOOL)shouldShowCancel OneDMode:(BOOL)shouldUseoOneDMode;
 - (id)initWithDelegate:(id<ZXingDelegate>)scanDelegate showCancel:(BOOL)shouldShowCancel OneDMode:(BOOL)shouldUseoOneDMode showLicense:(BOOL)shouldShowLicense;
+- (id)initWithDelegate:(id<ZXingDelegate>)scanDelegate frame:(CGRect)frame showCancel:(BOOL)shouldShowCancel OneDMode:(BOOL)shouldUseoOneDMode showLicense:(BOOL)shouldShowLicense;
 
 - (BOOL)fixedFocus;
 - (void)setTorch:(BOOL)status;

--- a/iphone/ZXingWidget/Classes/ZXingWidgetController.m
+++ b/iphone/ZXingWidget/Classes/ZXingWidgetController.m
@@ -56,30 +56,38 @@
 
 
 - (id)initWithDelegate:(id<ZXingDelegate>)scanDelegate showCancel:(BOOL)shouldShowCancel OneDMode:(BOOL)shouldUseoOneDMode {
-  
-  return [self initWithDelegate:scanDelegate showCancel:shouldShowCancel OneDMode:shouldUseoOneDMode showLicense:YES];
+    
+    return [self initWithDelegate:scanDelegate showCancel:shouldShowCancel OneDMode:shouldUseoOneDMode showLicense:YES];
 }
 
-- (id)initWithDelegate:(id<ZXingDelegate>)scanDelegate showCancel:(BOOL)shouldShowCancel OneDMode:(BOOL)shouldUseoOneDMode showLicense:(BOOL)shouldShowLicense {
-  self = [super init];
-  if (self) {
-    [self setDelegate:scanDelegate];
-    self.oneDMode = shouldUseoOneDMode;
-    self.showCancel = shouldShowCancel;
-    self.showLicense = shouldShowLicense;
-    self.wantsFullScreenLayout = YES;
-    beepSound = -1;
-    decoding = NO;
-    OverlayView *theOverLayView = [[OverlayView alloc] initWithFrame:[UIScreen mainScreen].bounds 
-                                                       cancelEnabled:showCancel 
-                                                            oneDMode:oneDMode
-                                                         showLicense:shouldShowLicense];
-    [theOverLayView setDelegate:self];
-    self.overlayView = theOverLayView;
-    [theOverLayView release];
-  }
-  
-  return self;
+- (id)initWithDelegate:(id<ZXingDelegate>)scanDelegate showCancel:(BOOL)shouldShowCancel OneDMode:(BOOL)shouldUseoOneDMode showLicense:(BOOL)shouldShowLicense
+{
+    return [self initWithDelegate:scanDelegate frame:CGRectNull showCancel:shouldShowCancel OneDMode:oneDMode showLicense:shouldShowLicense];
+}
+
+- (id)initWithDelegate:(id<ZXingDelegate>)scanDelegate frame:(CGRect)frame showCancel:(BOOL)shouldShowCancel OneDMode:(BOOL)shouldUseoOneDMode showLicense:(BOOL)shouldShowLicense {
+    self = [super init];
+    if (self) {
+        [self setDelegate:scanDelegate];
+        self.oneDMode = shouldUseoOneDMode;
+        self.showCancel = shouldShowCancel;
+        self.showLicense = shouldShowLicense;
+        if(CGRectEqualToRect(frame, CGRectNull)){
+            self.wantsFullScreenLayout = YES;
+            frame = [UIScreen mainScreen].bounds;
+        }
+        beepSound = -1;
+        decoding = NO;
+        OverlayView *theOverLayView = [[OverlayView alloc] initWithFrame:frame
+                                                           cancelEnabled:showCancel
+                                                                oneDMode:oneDMode
+                                                             showLicense:shouldShowLicense];
+        [theOverLayView setDelegate:self];
+        self.overlayView = theOverLayView;
+        [theOverLayView release];
+    }
+    
+    return self;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
Custom frame enables easy use to display the scanner in a UIPopoverController instead of showing it full-screen. An example can be found in the [zxing-ipad-example](https://github.com/krummler/zxing-ipad-example) project.

![screenshot](https://f.cloud.github.com/assets/1032307/145269/7a2aead6-745a-11e2-8fe3-7ee71b1b9306.png)
