### PR TITLE
Update GenericMultipleBarcodeReader.as

### DIFF
--- a/actionscript/core/src/com/google/zxing/multi/GenericMultipleBarcodeReader.as
+++ b/actionscript/core/src/com/google/zxing/multi/GenericMultipleBarcodeReader.as
@@ -66,6 +66,8 @@ package com.google.zxing.multi {
       var result:Result;
       try {
         result = delegate.decode(image, hints);
+        if( result == null)
+          return;
       } catch (re:ReaderException) {
         return;
       }


### PR DESCRIPTION
Added check for result of delegate.decode and returning if null.
This was causing the check (existingResult.getText() == result.getText() to fail resulting in an incorrect null return from the decodeMultiple function
