### PR TITLE
Specify allowed EAN extensions as a hint

### DIFF
--- a/core/src/main/java/com/google/zxing/DecodeHintType.java
+++ b/core/src/main/java/com/google/zxing/DecodeHintType.java
@@ -88,6 +88,15 @@ public enum DecodeHintType {
    */
   NEED_RESULT_POINT_CALLBACK(ResultPointCallback.class),
 
+
+  /**
+   * Allowed extension lengths for EAN or UPC barcodes.
+   * Other formats will ignore this.
+   * Maps to an {@code int[]} of the allowed extension lengths, for example [2], [5], or [2, 5].
+   * If it is optional to have an extension, do not set this hint.
+   */
+  ALLOWED_EAN_EXTENSIONS(int[].class);
+
   // End of enumeration values.
   ;
 


### PR DESCRIPTION
Related to this question:

http://stackoverflow.com/questions/8544503/zxing-scanning-barcode-with-upc-5-supplemental

The use case is an application that needs to scan EAN-13 + EAN-5 barcodes, optionally also needing to allow other formats (e.g. QR codes), but not EAN-13 by itself.

The actual decoding of EAN-5 works perfectly. The problem is that most of the time, the barcode scanner picks up the normal EAN-13 part before it found the EAN-5 extension, and returns only that. I've also found that it sometimes only returns the first two characters, as if it was an EAN-2 extension.

This change allows you to specify a hint to not return any EAN/UPC barcode, unless it found an extension of the specified length (EAN-2, EAN-5 or both).

This is the least obtrusive way I've found to allow scanning of EAN-13 + EAN-5 barcodes, while still allowing it to be used with other formats in MultiFormatReader.

An alternative and slightly more flexible solution would be to add formats like EAN_13_WITH_EAN_5, but there are no many combinations to make this practical.
