### PR TITLE
Code 39 Barcodes Generated Backwards

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/Code39Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/Code39Writer.java
@@ -68,7 +68,7 @@ public final class Code39Writer extends OneDimensionalCodeWriter {
     int[] narrowWhite = {1};
     pos += appendPattern(result, pos, narrowWhite, false);
     //append next character to bytematrix
-    for(int i = length-1; i >= 0; i--) {
+    for (int i = 0; i < length; i++) {
       int indexInString = Code39Reader.ALPHABET_STRING.indexOf(contents.charAt(i));
       toIntArray(Code39Reader.CHARACTER_ENCODINGS[indexInString], widths);
       pos += appendPattern(result, pos, widths, true);
@@ -81,7 +81,7 @@ public final class Code39Writer extends OneDimensionalCodeWriter {
 
   private static void toIntArray(int a, int[] toReturn) {
     for (int i = 0; i < 9; i++) {
-      int temp = a & (1 << i);
+      int temp = a & (1 << (8 - i));
       toReturn[i] = temp == 0 ? 1 : 2;
     }
   }


### PR DESCRIPTION
Code 39 barcodes generated by zxing seem to be backwards. In other words, they appear to be rotated 180 degrees. For example, here is a Code 39 barcode from the Wikipedia entry for Code 39:

![393px-code_3_of_9 svg](https://f.cloud.github.com/assets/3630377/2247070/2f312316-9d6b-11e3-8d86-3a25a50fbb78.png)

And here is the barcode ZXing generates:

![zxing_original_screenshot](https://f.cloud.github.com/assets/3630377/2247081/3b80e5e8-9d6b-11e3-8614-035b72527c21.png)

Here is the barcode generated by ZXing after the change in this request:

![zxing_pull_request_screenshot](https://f.cloud.github.com/assets/3630377/2247101/5b7d9224-9d6b-11e3-986b-11443b6d0ea4.png)
