### PR TITLE
Updates for XE16 compatibility.  

### DIFF
--- a/glass/AndroidManifest.xml
+++ b/glass/AndroidManifest.xml
@@ -20,6 +20,8 @@
           android:versionName="0.2.0">
 
   <uses-permission android:name="android.permission.CAMERA"/>
+  <uses-permission android:name="com.google.android.glass.permission.DEVELOPMENT" />
+  
 
   <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="19"/>
 

--- a/glass/res/xml/barcode_scanner_show.xml
+++ b/glass/res/xml/barcode_scanner_show.xml
@@ -14,6 +14,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<trigger command="TRANSLATE_THIS">
+<trigger keyword="BARCODE SCANNER">
   <constraints camera="true" />
 </trigger>


### PR DESCRIPTION
XE16 was released in April 2014 and replaced XE12 from December 2013.  XE16 changes the way voice triggers are set up.  They now require a permission in the manifest and use a different trigger syntax.

I also changed the trigger to be more relevant for zxing.

I tested this on Glass and it works.
