### PR TITLE
Use ARGB color model in MatrixToImageConfig

### DIFF
--- a/javase/src/main/java/com/google/zxing/client/j2se/MatrixToImageConfig.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/MatrixToImageConfig.java
@@ -56,7 +56,7 @@ public final class MatrixToImageConfig {
 
   int getBufferedImageColorModel() {
     // Use faster BINARY if colors match default
-    return onColor == BLACK && offColor == WHITE ? BufferedImage.TYPE_BYTE_BINARY : BufferedImage.TYPE_INT_RGB;
+    return onColor == BLACK && offColor == WHITE ? BufferedImage.TYPE_BYTE_BINARY : BufferedImage.TYPE_INT_ARGB;
   }
 
 }


### PR DESCRIPTION
ARGB Color model must be used to allow offColor be transparent
