### PR TITLE
Added .gitattributes to define how git handles the line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.java text
+
+# Declare files that will always have LF line endings on checkout.
+*.txt text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary


### PR DESCRIPTION
When checking out the source code under windows the line endings of the txt files in the test cases got converted to CRLF.
The .gitattributes files defines to leave the *.txt files with LF line ending. This way the tests also pass under Windows.
