### PR TITLE
return full text contain \r

### DIFF
--- a/android/src/com/google/zxing/client/android/result/TextResultHandler.java
+++ b/android/src/com/google/zxing/client/android/result/TextResultHandler.java
@@ -70,6 +70,12 @@ public final class TextResultHandler extends ResultHandler {
   }
 
   @Override
+  public CharSequence getDisplayContents() {
+    String contents = result.getDisplayResult();
+    return contents;
+  }
+
+  @Override
   public int getDisplayTitle() {
     return R.string.result_text;
   }


### PR DESCRIPTION
some barcode contain '\r' ,so i think return full text not replace "\r" -> ""
thx