### PR TITLE
minSize from provided sizes

### DIFF
--- a/core/src/main/java/com/google/zxing/datamatrix/DataMatrixWriter.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/DataMatrixWriter.java
@@ -60,7 +60,7 @@ public final class DataMatrixWriter implements Writer {
 
     // Try to get force shape & min / max size
     SymbolShapeHint shape = SymbolShapeHint.FORCE_NONE;
-    Dimension minSize = null;
+    Dimension minSize = new Dimension(width, height);
     Dimension maxSize = null;
     if (hints != null) {
       SymbolShapeHint requestedShape = (SymbolShapeHint) hints.get(EncodeHintType.DATA_MATRIX_SHAPE);


### PR DESCRIPTION
create minSize Dimension from provided width and height. If minsize is provided inside hints, it still gets overwritten
it was not tested, tests failed at aztec barcode
