### PR TITLE
Add info to the README about active C++ port and Ruby bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ There are also additional modules which are contributed and/or intermittently ma
 
 ### Related third-party open source projects
 
-| Module                                             | Description
-| -------------------------------------------------- | -----------
-| [QZXing](https://sourceforge.net/projects/qzxing)  | port to Qt framework
-| [ZXing .NET](http://zxingnet.codeplex.com/)        | port to .NET and C#, and related Windows platform
+| Module                                                          | Description
+| --------------------------------------------------------------- | -----------
+| [QZXing](https://sourceforge.net/projects/qzxing)               | port to Qt framework
+| [zxing-cpp](https://github.com/glassechidna/zxing-cpp)          | port to C++ (forked from the [deprecated official C++ port](https://github.com/zxing/zxing/tree/00f634024ceeee591f54e6984ea7dd666fab22ae/cpp))
+| [zxing_cpp.rb](https://github.com/glassechidna/zxing_cpp.rb)    | bindings for Ruby (not just JRuby), powered by [zxing-cpp](https://github.com/glassechidna/zxing-cpp)
+| [ZXing .NET](http://zxingnet.codeplex.com/)                     | port to .NET and C#, and related Windows platform
 
 ### Other third-party open source projects
 


### PR DESCRIPTION
I forked the old deleted C++ code into it's own [light-weight repo](https://github.com/glassechidna/zxing-cpp), as I wanted to build some [regular Ruby (not JRuby) bindings](https://github.com/glassechidna/zxing_cpp.rb).

The Ruby bindings are actually just a fork of [Steven's Ruby bindings](https://github.com/smparkes/zxing.rb), where I've mostly just removed all the JRuby and MacRuby bits and then added all the stuff necessary to package and publish a [zxing_cpp gem](http://rubygems.org/gems/zxing_cpp).

Anyway, this commit just adds some info about the projects to the README so people looking for an active C++ port and some Ruby bindings can find them.
