### PR TITLE
dependency-info.html: sbt should use %

### DIFF
--- a/dependency-info.html
+++ b/dependency-info.html
@@ -201,7 +201,7 @@
 <div class="section">
 <h3>SBT<a name="SBT"></a></h3><a name="SBT"></a>
 <div class="source">
-<pre>libraryDependencies += &quot;com.google.zxing&quot; %% &quot;zxing-parent&quot; % &quot;3.1.0&quot;</pre></div></div></div>
+<pre>libraryDependencies += &quot;com.google.zxing&quot; % &quot;zxing-parent&quot; % &quot;3.1.0&quot;</pre></div></div></div>
                   </div>
             </div>
           </div>


### PR DESCRIPTION
%% is for libraries cross-built against different scala versions.