### PR TITLE
Fixed little typo and restored Data Matrix instead of italian's literal ...

### DIFF
--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -77,7 +77,7 @@
   <string name="msg_redirect">Inoltra</string>
   <string name="msg_sbc_book_not_searchable">Spiacenti, questo libro non è ricercabile.</string>
   <string name="msg_sbc_failed">Spiacenti, la ricerca ha avuto un problema.</string>
-  <string name="msg_sbc_no_page_returned">Nessuna pagina restitiuta</string>
+  <string name="msg_sbc_no_page_returned">Nessuna pagina restituita</string>
   <string name="msg_sbc_page">Pagina</string>
   <string name="msg_sbc_results">Risultati</string>
   <string name="msg_sbc_searching_book">Ricerca libro\u2026</string>
@@ -97,7 +97,7 @@
   <string name="preferences_decode_1D_industrial_title">1D industriali</string>
   <string name="preferences_decode_1D_product_title">1D prodotto</string>
   <string name="preferences_decode_Aztec_title">Aztec</string>
-  <string name="preferences_decode_Data_Matrix_title">Matrice Dati</string>
+  <string name="preferences_decode_Data_Matrix_title">Data Matrix</string>
   <string name="preferences_decode_PDF417_title">PDF417 (β)</string>
   <string name="preferences_decode_QR_title">Codici QR</string>
   <string name="preferences_device_bug_workarounds_title">Soluzioni alternative dispositivo Bug</string>


### PR DESCRIPTION
...translation

Line 80: restitiuta > restituita
Line 100: Matrice dati > Data Matrix (currently in Italy this 2d barcode is known with its english name and shouldn't be translated ;-)