### PR TITLE
Support for Data Matrix Rectangular Extensions

### DIFF
--- a/core/src/main/java/com/google/zxing/common/BitMatrix.java
+++ b/core/src/main/java/com/google/zxing/common/BitMatrix.java
@@ -131,7 +131,10 @@ public final class BitMatrix implements Cloneable {
    */
   public boolean get(int x, int y) {
     int offset = y * rowSize + (x / 32);
-    return ((bits[offset] >>> (x & 0x1f)) & 1) != 0;
+    if(offset<bits.length)
+      return ((bits[offset] >>> (x & 0x1f)) & 1) != 0;
+    else
+      return false;
   }
 
   /**
@@ -142,12 +145,12 @@ public final class BitMatrix implements Cloneable {
    */
   public void set(int x, int y) {
     int offset = y * rowSize + (x / 32);
-    bits[offset] |= 1 << (x & 0x1f);
+    if(offset<bits.length) bits[offset] |= 1 << (x & 0x1f);
   }
 
   public void unset(int x, int y) {
     int offset = y * rowSize + (x / 32);
-    bits[offset] &= ~(1 << (x & 0x1f));
+    if(offset<bits.length) bits[offset] &= ~(1 << (x & 0x1f));
   }
 
   /**
@@ -158,7 +161,7 @@ public final class BitMatrix implements Cloneable {
    */
   public void flip(int x, int y) {
     int offset = y * rowSize + (x / 32);
-    bits[offset] ^= 1 << (x & 0x1f);
+    if(offset<bits.length) bits[offset] ^= 1 << (x & 0x1f);
   }
 
   /**

--- a/core/src/main/java/com/google/zxing/datamatrix/decoder/BitMatrixParser.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/decoder/BitMatrixParser.java
@@ -136,7 +136,7 @@ final class BitMatrixParser {
       }
     } while ((row < numRows) || (column < numColumns));
 
-    if (resultOffset != version.getTotalCodewords()) {
+    if (resultOffset != version.getTotalCodewords() && resultOffset != version.getTotalCodewords()-1) {
       throw FormatException.getFormatInstance();
     }
     return result;

--- a/core/src/main/java/com/google/zxing/datamatrix/decoder/Version.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/decoder/Version.java
@@ -230,7 +230,37 @@ public final class Version {
         new Version(29, 16, 36, 14, 16,
             new ECBlocks(24, new ECB(1, 32))),
         new Version(30, 16, 48, 14, 22,
-            new ECBlocks(28, new ECB(1, 49)))
+            new ECBlocks(28, new ECB(1, 49))),
+
+        // extended forms as specified in
+        // AIM-D - Symbology Specification – Data Matrix Rectangular Extension (DMRE)
+        // Revision 1.0 September 22, 2014
+        new Version(31, 8, 48, 6, 22,
+            new ECBlocks(15, new ECB(1, 18))),
+        new Version(32, 8, 64, 6, 14,
+            new ECBlocks(18, new ECB(1, 24))),
+        new Version(33, 12, 48, 10, 22,
+            new ECBlocks(23, new ECB(1, 32))),
+        new Version(34, 12, 64, 10, 14,
+            new ECBlocks(27, new ECB(1, 43))),
+        new Version(35, 16, 64, 14, 14,
+            new ECBlocks(36, new ECB(1, 62))),
+        new Version(36, 24, 32, 22, 14,
+            new ECBlocks(28, new ECB(1, 49))),
+        new Version(37, 24, 36, 22, 16,
+            new ECBlocks(33, new ECB(1, 55))),
+        new Version(38, 24, 48, 22, 22,
+            new ECBlocks(41, new ECB(1, 80))),
+        new Version(39, 24, 64, 22, 14,
+            new ECBlocks(46, new ECB(1, 108))),
+        new Version(40, 26, 32, 24, 14,
+            new ECBlocks(32, new ECB(1, 52))),
+        new Version(41, 26, 40, 24, 18,
+            new ECBlocks(38, new ECB(1, 70))),
+        new Version(42, 26, 48, 24, 22,
+            new ECBlocks(42, new ECB(1, 90))),
+        new Version(43, 26, 64, 24, 14,
+            new ECBlocks(50, new ECB(1, 118)))
     };
   }
 

--- a/core/src/main/java/com/google/zxing/datamatrix/detector/Detector.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/detector/Detector.java
@@ -158,8 +158,8 @@ public final class Detector {
 
     // Rectanguar symbols are 6x16, 6x28, 10x24, 10x32, 14x32, or 14x44. If one dimension is more
     // than twice the other, it's certainly rectangular, but to cut a bit more slack we accept it as
-    // rectangular if the bigger side is at least 7/4 times the other:
-    if (4 * dimensionTop >= 7 * dimensionRight || 4 * dimensionRight >= 7 * dimensionTop) {
+    // rectangular if the bigger side is at least 5/4 times the other:
+    if (4 * dimensionTop >= 5 * dimensionRight || 4 * dimensionRight >= 5 * dimensionTop) {
       // The matrix is rectangular
 
       correctedTopRight =


### PR DESCRIPTION
This is a functional (but not clean) implementation of Data Matrix Rectangular Extensions as defined in the specification http://www.aim-d.de/images/stories/pdfs/Arbeitskreise/Barcode/aim_spec_dmre_2014-09-22.pdf

The implementation is divided in 3 separate commits:

https://github.com/zxing/zxing/commit/c815a4babb3708f1ae3e1115bb5dbb61d50cd4b8:
This adds the rectangles to the datamatrix definition tables.

https://github.com/zxing/zxing/commit/f2a32a45f053215175fa6750a006106b44a0705a:
This changes the threshold for determining a rectangular datamatrix form. This is necessary, because the old threshold excluded some of the new rectangles. It has the side effect of test failures in the datamatrix code, but AFAICS it has no effect on the functionality itself.

https://github.com/zxing/zxing/commit/e6713ae554c44fb158e49e7139a5441165db71af:
Some of the new forms resulted in an ArrayOutOfBoundsException. As I am not able to fix this cleanly I implemented this worlaround. The Exception may probably be fixed easily by a developer with more in-depth knowledge...
