### PR TITLE
Fixed the cameraId changing on powerbutton press

### DIFF
--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -176,16 +176,6 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     resetStatusView();
 
-    SurfaceView surfaceView = (SurfaceView) findViewById(R.id.preview_view);
-    SurfaceHolder surfaceHolder = surfaceView.getHolder();
-    if (hasSurface) {
-      // The activity was paused but not stopped, so the surface still exists. Therefore
-      // surfaceCreated() won't be called, so init the camera here.
-      initCamera(surfaceHolder);
-    } else {
-      // Install the callback and wait for surfaceCreated() to init the camera.
-      surfaceHolder.addCallback(this);
-    }
 
     beepManager.updatePrefs();
     ambientLightManager.start(cameraManager);
@@ -260,6 +250,17 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
       characterSet = intent.getStringExtra(Intents.Scan.CHARACTER_SET);
 
+    }
+
+    SurfaceView surfaceView = (SurfaceView) findViewById(R.id.preview_view);
+    SurfaceHolder surfaceHolder = surfaceView.getHolder();
+    if (hasSurface) {
+      // The activity was paused but not stopped, so the surface still exists. Therefore
+      // surfaceCreated() won't be called, so init the camera here.
+      initCamera(surfaceHolder);
+    } else {
+      // Install the callback and wait for surfaceCreated() to init the camera.
+      surfaceHolder.addCallback(this);
     }
   }
 


### PR DESCRIPTION
When using the QR code reader with a front facing camera (non-default camera) if you turn the screen off and on (pressing power button) the camera being used changes to the default camera. This occurs because when the screen is turned off and on the surfaceView is not destroyed causing a different  behavior in CaptureActivity.onResume(). The surfaceView not being destroyed causes the CameraManager to open the camera before setting the cameraId. This pull request has reordered these operations to make sure the manual setting of cameraId inside CaptureActivity.onResume() occurs before the CameraManager opening the camera.

For more information see the following post:
https://groups.google.com/forum/#!topic/zxing/CguxsAm0SjE