### PR TITLE
Use result metadata to return Code39 Full-ASCII decoded value and checksum status

### DIFF
--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -93,7 +93,8 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
       EnumSet.of(ResultMetadataType.ISSUE_NUMBER,
                  ResultMetadataType.SUGGESTED_PRICE,
                  ResultMetadataType.ERROR_CORRECTION_LEVEL,
-                 ResultMetadataType.POSSIBLE_COUNTRY);
+                 ResultMetadataType.POSSIBLE_COUNTRY,
+                 ResultMetadataType.CODE_39_EXTENDED);
 
   private CameraManager cameraManager;
   private CaptureActivityHandler handler;

--- a/core/src/main/java/com/google/zxing/ResultMetadataType.java
+++ b/core/src/main/java/com/google/zxing/ResultMetadataType.java
@@ -93,5 +93,15 @@ public enum ResultMetadataType {
    * parity is given with it.
    */
   STRUCTURED_APPEND_PARITY,
-  
+
+  /**
+   * For Code39 this contains the decoded contents with the Full-ASCII range.
+   */
+  CODE_39_EXTENDED,
+
+  /**
+   * For Code39 this contains a boolean marking whether the checksum is valid.
+   */
+  CODE_39_CHECKSUM_CORRECT,
+
 }


### PR DESCRIPTION
The proposed change will:
* attempt to decode Code39 in Full-ASCII form, and if successful will return it as a result meta-data.
* attempt to calculate the checksum and return the state as a result meta-data
* display the Code39 Full-ASCII result in the Android scanner screen

TODO:
* Handle codes that have a checksum and are encoded using the Code39 Full-ASCII form