### PR TITLE
Decode HTML entities in titles

### DIFF
--- a/android/src/com/google/zxing/client/android/result/supplement/TitleRetriever.java
+++ b/android/src/com/google/zxing/client/android/result/supplement/TitleRetriever.java
@@ -16,6 +16,7 @@
 
 package com.google.zxing.client.android.result.supplement;
 
+import android.text.Html;
 import android.widget.TextView;
 import com.google.zxing.client.android.HttpHelper;
 import com.google.zxing.client.android.history.HistoryManager;
@@ -56,6 +57,7 @@ final class TitleRetriever extends SupplementalInfoRetriever {
       if (m.find()) {
         String title = m.group(1);
         if (title != null && !title.isEmpty()) {
+          title = Html.fromHtml(title).toString();
           if (title.length() > MAX_TITLE_LEN) {
             title = title.substring(0, MAX_TITLE_LEN) + "...";
           }


### PR DESCRIPTION
This allows page titles with HTML entities like `&amp;` to display properly. Before, no decoding would be performed and `&amp;` would be shown where an ampersand should be. Additionally, decoding entities prevents the following string length check from overcounting.

To replicate this bug scan an image with a URL pointing to http://stackoverflow.com/questions/tagged/android The title displayed within the app will be something like: `Frequent &#39;android&#39; Questions - Stack Overflow` After this commit, the app will display the correct decoded title: `Frequent 'android' Questions - Stack Overflow`

Alternatively, scan this to replicate:
![http://stackoverflow.com/questions/tagged/android](http://zxing.org/w/chart?cht=qr&chs=120x120&chld=L&choe=UTF-8&chl=http%3A%2F%2Fstackoverflow.com%2Fquestions%2Ftagged%2Fandroid)