### PR TITLE
Fixed substring call

### DIFF
--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -215,7 +215,7 @@ final class PDF417HighLevelEncoder {
             if (b == 0) {
               b = 1;
             }
-            byte[] bytes = msg.substring(p, b).getBytes(encoding);
+            byte[] bytes = msg.substring(p, p + b).getBytes(encoding);
             if (bytes.length == 1 && encodingMode == TEXT_COMPACTION) {
               //Switch for one byte (instead of latch)
               encodeBinary(bytes, 0, 1, TEXT_COMPACTION, sb);

--- a/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
@@ -36,6 +36,12 @@ public final class PDF417EncoderTestCase extends Assert {
     PDF417HighLevelEncoder.encodeHighLevel(
         "1%§s ?aG$", Compaction.AUTO, StandardCharsets.UTF_8);
   }
+  
+  @Test
+  public void testEncodeIso88591WithSpecialChars() throws Exception {
+	  // Just check if this does not throw an exception
+	  PDF417HighLevelEncoder.encodeHighLevel("asdfg§asd", Compaction.AUTO, StandardCharsets.ISO_8859_1);
+  }
 
   @Test
   public void testEncodeText() throws Exception {


### PR DESCRIPTION
Fixed a bug when calling String.substring introduced in https://github.com/zxing/zxing/pull/395, which caused an exception when for example trying to encode "sadfg$sad" in PDF417 with the default encoding (ISO-8859-1)