### PR TITLE
PDF417Writer shouldn't ignore ERROR_CORRECTION hint

### DIFF
--- a/core/src/main/java/com/google/zxing/EncodeHintType.java
+++ b/core/src/main/java/com/google/zxing/EncodeHintType.java
@@ -27,7 +27,8 @@ public enum EncodeHintType {
    * Specifies what degree of error correction to use, for example in QR Codes.
    * Type depends on the encoder. For example for QR codes it's type
    * {@link com.google.zxing.qrcode.decoder.ErrorCorrectionLevel ErrorCorrectionLevel}.
-   * For Aztec it is of type {@link Integer}, representing the minimal percentage of error correction words. 
+   * For Aztec it is of type {@link Integer}, representing the minimal percentage of error correction words.
+   * For PDF417 it is of type {@link Integer}, valid values being 0 to 8.
    * Note: an Aztec symbol should have a minimum of 25% EC words.
    */
   ERROR_CORRECTION,

--- a/core/src/main/java/com/google/zxing/pdf417/PDF417Writer.java
+++ b/core/src/main/java/com/google/zxing/pdf417/PDF417Writer.java
@@ -39,6 +39,11 @@ public final class PDF417Writer implements Writer {
    */
   static final int WHITE_SPACE = 30;
 
+  /**
+   * default error correction level
+   */
+  static final int DEFAULT_ERROR_CORRECTION_LEVEL = 2;
+
   @Override
   public BitMatrix encode(String contents,
                           BarcodeFormat format,
@@ -51,6 +56,7 @@ public final class PDF417Writer implements Writer {
 
     PDF417 encoder = new PDF417();
     int margin = WHITE_SPACE;
+    int errorCorrectionLevel = DEFAULT_ERROR_CORRECTION_LEVEL;
 
     if (hints != null) {
       if (hints.containsKey(EncodeHintType.PDF417_COMPACT)) {
@@ -69,13 +75,16 @@ public final class PDF417Writer implements Writer {
       if (hints.containsKey(EncodeHintType.MARGIN)) {
         margin = ((Number) hints.get(EncodeHintType.MARGIN)).intValue();
       }
+      if (hints.containsKey(EncodeHintType.ERROR_CORRECTION)) {
+        errorCorrectionLevel = ((Number) hints.get(EncodeHintType.ERROR_CORRECTION)).intValue();
+      }
       if (hints.containsKey(EncodeHintType.CHARACTER_SET)) {
         String encoding = (String) hints.get(EncodeHintType.CHARACTER_SET);
         encoder.setEncoding(Charset.forName(encoding));
       }
     }
 
-    return bitMatrixFromEncoder(encoder, contents, width, height, margin);
+    return bitMatrixFromEncoder(encoder, contents, errorCorrectionLevel, width, height, margin);
   }
 
   @Override
@@ -91,10 +100,10 @@ public final class PDF417Writer implements Writer {
    */
   private static BitMatrix bitMatrixFromEncoder(PDF417 encoder,
                                                 String contents,
+                                                int errorCorrectionLevel,
                                                 int width,
                                                 int height,
                                                 int margin) throws WriterException {
-    int errorCorrectionLevel = 2;
     encoder.generateBarcodeLogic(contents, errorCorrectionLevel);
 
     int aspectRatio = 4;


### PR DESCRIPTION
I ran across this limitation while comparing zxing PDF417 output to Okapi PDF417 output.

The contribution is my original work and I license the work to the project under the project's open source license.