### PR TITLE
Add choice of the correction error level for qr code

### DIFF
--- a/javase/src/main/java/com/google/zxing/client/j2se/CommandLineEncoder.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/CommandLineEncoder.java
@@ -19,9 +19,13 @@ package com.google.zxing.client.j2se;
 import com.beust.jcommander.JCommander;
 import com.google.zxing.MultiFormatWriter;
 import com.google.zxing.common.BitMatrix;
+import com.google.zxing.EncodeHintType;
+
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 
 import java.nio.file.Paths;
 import java.util.Locale;
+import java.util.HashMap;
 
 /**
  * Command line utility for encoding barcodes.
@@ -47,8 +51,35 @@ public final class CommandLineEncoder {
       outFileString += '.' + config.imageFormat.toLowerCase(Locale.ENGLISH);
     }
     
-    BitMatrix matrix = new MultiFormatWriter().encode(
+    BitMatrix matrix = null;
+    if (config.errorCorrectionLevel != -1) {
+      ErrorCorrectionLevel hintsval;
+      switch (config.barcodeFormat) {
+        case QR_CODE:
+          if (config.errorCorrectionLevel.equals(0)) {
+              hintsval = ErrorCorrectionLevel.M;
+          } else if (config.errorCorrectionLevel.equals(1)) {
+              hintsval = ErrorCorrectionLevel.L;
+          } else if (config.errorCorrectionLevel.equals(2)) {
+              hintsval = ErrorCorrectionLevel.H;
+          } else if (config.errorCorrectionLevel.equals(3)) {
+              hintsval = ErrorCorrectionLevel.Q;
+          } else {
+            throw new IllegalArgumentException("No correction error available for level " + config.errorCorrectionLevel);
+          }
+          break;
+        default:
+          throw new IllegalArgumentException("No encoder available for format " + config.barcodeFormat + " with error correction level " + config.errorCorrectionLevel);
+      }
+      HashMap<EncodeHintType,ErrorCorrectionLevel> hints = new HashMap<EncodeHintType,ErrorCorrectionLevel>(); 
+      hints.put(EncodeHintType.ERROR_CORRECTION,hintsval);
+      matrix = new MultiFormatWriter().encode(
+        config.contents.get(0), config.barcodeFormat, config.width, config.height, hints);
+
+    } else {
+        matrix = new MultiFormatWriter().encode(
         config.contents.get(0), config.barcodeFormat, config.width, config.height);
+      }
     MatrixToImageWriter.writeToPath(matrix, config.imageFormat, Paths.get(outFileString));
   }
 

--- a/javase/src/main/java/com/google/zxing/client/j2se/EncoderConfig.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/EncoderConfig.java
@@ -48,6 +48,13 @@ final class EncoderConfig {
       validateWith = PositiveInteger.class)
   int height = 300;
 
+  @Parameter(names = "--error_correction_level",
+      description = "The error correction level change depending on the format."
+             + "Starts at 0 and the max depends on the barcode type (-1 for default)."
+             + "For QR code, 0->M, 1->L,2->H,3->Q",
+      help = true)
+  Integer errorCorrectionLevel = -1;
+
   @Parameter(names = "--help",
       description = "Prints this help message",
       help = true)


### PR DESCRIPTION
Hi,
I have done the modification that I have spoken about, It add an option in the command line encoder for choosing the correction error level. I have chosen an integer to define it due to the different bar code format and their correction level class (the change to a char can be quickly done if needed).