### PR TITLE
Create a specific DataMatrixWriter to generate 2D-Doc

### DIFF
--- a/core/src/main/java/com/google/zxing/datamatrix/DDDocWriter.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/DDDocWriter.java
@@ -1,0 +1,10 @@
+package com.google.zxing.datamatrix;
+
+import com.google.zxing.datamatrix.encoder.HighLevelEncoder;
+
+public class DDDocWriter extends DataMatrixWriter {
+
+    public DDDocWriter(){
+        super(HighLevelEncoder.DDDOC_ENCODATION);
+    }
+}

--- a/core/src/main/java/com/google/zxing/datamatrix/DDDocWriter.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/DDDocWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2008 ZXing authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.zxing.datamatrix;
 
 import com.google.zxing.datamatrix.encoder.HighLevelEncoder;

--- a/core/src/main/java/com/google/zxing/datamatrix/DataMatrixWriter.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/DataMatrixWriter.java
@@ -36,7 +36,18 @@ import java.util.Map;
  * @author dswitkin@google.com (Daniel Switkin)
  * @author Guillaume Le Biller Added to zxing lib.
  */
-public final class DataMatrixWriter implements Writer {
+public class DataMatrixWriter implements Writer {
+
+  protected int defaultEncoding;
+
+  public DataMatrixWriter(){
+    this(HighLevelEncoder.ASCII_ENCODATION);
+  }
+
+  public DataMatrixWriter(int defaultEncoding) {
+    super();
+    this.defaultEncoding = defaultEncoding;
+  }
 
   @Override
   public BitMatrix encode(String contents, BarcodeFormat format, int width, int height) {
@@ -81,7 +92,7 @@ public final class DataMatrixWriter implements Writer {
 
 
     //1. step: Data encodation
-    String encoded = HighLevelEncoder.encodeHighLevel(contents, shape, minSize, maxSize);
+    String encoded = HighLevelEncoder.encodeHighLevel(contents, shape, minSize, maxSize, defaultEncoding);
 
     SymbolInfo symbolInfo = SymbolInfo.lookup(encoded.length(), shape, minSize, maxSize, true);
 

--- a/core/src/main/java/com/google/zxing/datamatrix/encoder/DDDocEncoder.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/encoder/DDDocEncoder.java
@@ -1,0 +1,197 @@
+package com.google.zxing.datamatrix.encoder;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.InvalidParameterException;
+
+public class DDDocEncoder implements Encoder{
+
+    @Override
+    public int getEncodingMode() {
+        return HighLevelEncoder.DDDOC_ENCODATION;
+    }
+
+    @Override
+    public void encode(EncoderContext context) {
+        String message = context.getMessage();
+
+        try {
+            ByteArrayInputStream input = new ByteArrayInputStream(message.getBytes("ISO-8859-1"));
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            encodeToC40(input, output);
+            input.close();
+            output.close();
+
+            byte[] byteArray = output.toByteArray();
+            output = new ByteArrayOutputStream();
+
+            int dataLength = encodeDataMatrix(new ByteArrayInputStream(byteArray), output);
+            input.close();
+
+            addPadding(dataLength, getDataMatrixStorageCapacity(dataLength), output, isReturnedToASCII(byteArray));
+
+            output.close();
+
+            byte[] byteEncoded = output.toByteArray();
+            context.writeCodewords(new String(byteEncoded, "ISO-8859-1"));
+        } catch (IOException arg0){
+            arg0.printStackTrace();
+        }
+    }
+
+    /**
+     * Encode to C40 the given InputStream into the OutputStream.
+     *
+     * @param input  The InputStream to be encoded.
+     * @param output The OutputStream where encoded data will be written
+     * @throws IOException
+     */
+    private void encodeToC40(InputStream input, OutputStream output) throws IOException {
+        int reader;
+
+        while((reader = input.read()) > -1){
+            if(reader >= 128){
+                output.write(1);
+                output.write(30);
+                reader -= 128;
+            }
+
+            if(reader >= 0 && reader <= 31){
+                output.write(0);
+                output.write(reader);
+            } else if(reader == 32){
+                output.write(3);
+            } else if(reader >= 33 && reader <= 47){
+                output.write(1);
+                output.write(reader-33);
+            } else if(reader >= 48 && reader <= 57){
+                output.write(reader-44);
+            } else if(reader >= 58 && reader <= 64){
+                output.write(1);
+                output.write(reader-43);
+            } else if(reader >= 65 && reader <= 90){
+                output.write(reader-51);
+            } else if(reader >= 91 && reader <= 95){
+                output.write(1);
+                output.write(reader-69);
+            } else if(reader >= 96 && reader <= 127){
+                output.write(2);
+                output.write(reader-96);
+            } else{
+                throw new IOException("Byte greater than 256 ! : "+reader);
+            }
+        }
+    }
+
+    /**
+     * Encode to Data Matrix the given InputStream into the OutputStream.
+     *
+     * @param input  The InputStream to be encoded.
+     * @param output The OutputStream where encoded data will be written.
+     * @return The length of encoded data.
+     * @throws IOException
+     */
+    private int encodeDataMatrix(InputStream input, OutputStream output) throws IOException{
+        int dataLength = 0;
+        int c1, c2, c3;
+
+        output.write(0xe6); //begin C40 encoding
+        dataLength++;
+
+        while((c1 = input.read())> -1){
+            if((c2 = input.read()) > -1){
+                if((c3 = input.read()) <= -1){
+                    c3 = 0;
+                }
+
+                int val = 1600*c1 + 40*c2 + c3 +1;
+
+                output.write(val >> 8);
+                output.write(val & 0xff);
+
+                dataLength += 2;
+            } else {
+                output.write(0xfe); //return to ASCII encoding
+
+                if(c1 == 3){
+                    output.write(32);
+                } else if(c1 >= 4 && c1 <= 13){
+                    output.write(c1+44);
+                } else if(c1 >= 14 && c1 <= 39){
+                    output.write(c1+51);
+                }
+
+                dataLength += 2;
+            }
+        }
+
+        return dataLength;
+    }
+
+    private boolean isReturnedToASCII(byte[] data){
+        return (data.length % 3 == 1);
+    }
+
+    private void addPadding(int dataLength, int dataMatrixStorageCapacity, OutputStream output, boolean isReturnedToASCII) throws IOException{
+        int countSpaceUsed = dataLength;
+        boolean flagPadding = false;
+
+        while (countSpaceUsed < dataMatrixStorageCapacity) {
+            if (isReturnedToASCII) {
+
+                if (flagPadding) {
+                    output.write(paddingRandomAlgorithm(countSpaceUsed + 1));
+                    countSpaceUsed++;
+                } else {
+                    output.write(129);
+                    flagPadding = true; //indicate that the padding has been started
+                    countSpaceUsed++;
+                }
+            } else {
+                output.write(0xfe); //return to ASCII encoding
+                isReturnedToASCII = true;
+                countSpaceUsed++;
+            }
+        }
+
+    }
+
+    private int getDataMatrixStorageCapacity(int dataLength) throws InvalidParameterException{
+        int[] arrayOfDataMatrixStorageCapacity = {114, 144, 174, 204, 280, 368, 456, 576, 696, 816, 1050, 1304, 1558};
+        int dataMatrixStorageCapacity = arrayOfDataMatrixStorageCapacity[0];
+
+        for(int i = 0; i < arrayOfDataMatrixStorageCapacity.length; i++){
+            if(dataLength > arrayOfDataMatrixStorageCapacity[i]){
+                if(i == arrayOfDataMatrixStorageCapacity.length - 1) {
+                    throw new InvalidParameterException("There is not enough storage capacity : "+dataLength+" -> max : "+dataMatrixStorageCapacity);
+                }
+                dataMatrixStorageCapacity = arrayOfDataMatrixStorageCapacity[i+1];
+            } else{
+                break;
+            }
+        }
+
+        return dataMatrixStorageCapacity;
+    }
+
+    /**
+     * Generate the padding value in accordance with the 253-state randomising algorithm.
+     *
+     * @param paddingPosition  The padding position.
+     * @return The padding value for a Data Matrix padding.
+     */
+    private int paddingRandomAlgorithm(int paddingPosition){
+        //253-state randomising algorithm applies to 2D-Doc padding
+        int value = ((149*paddingPosition) % 253) + 1;
+        int var = 129 + value; //value of padding = 129
+
+        if(var <= 254){
+            return var;
+        } else{
+            return var-254;
+        }
+    }
+}

--- a/core/src/main/java/com/google/zxing/datamatrix/encoder/DDDocEncoder.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/encoder/DDDocEncoder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2008 ZXing authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.zxing.datamatrix.encoder;
 
 import java.io.ByteArrayInputStream;

--- a/core/src/main/java/com/google/zxing/datamatrix/encoder/HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/encoder/HighLevelEncoder.java
@@ -143,6 +143,14 @@ public final class HighLevelEncoder {
     return encodeHighLevel(msg, SymbolShapeHint.FORCE_NONE, null, null, ASCII_ENCODATION);
   }
 
+
+  public static String encodeHighLevel(String msg,
+      SymbolShapeHint shape,
+      Dimension minSize,
+      Dimension maxSize) {
+    return encodeHighLevel(msg, shape, minSize, maxSize, ASCII_ENCODATION);
+  }
+
   /**
    * Performs message encoding of a DataMatrix message using the algorithm described in annex P
    * of ISO/IEC 16022:2000(E).

--- a/core/src/main/java/com/google/zxing/datamatrix/encoder/HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/encoder/HighLevelEncoder.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
  * annex S.
  */
 public final class HighLevelEncoder {
-  
+
   /**
    * Padding character
    */
@@ -101,12 +101,13 @@ public final class HighLevelEncoder {
    */
   private static final String MACRO_TRAILER = "\u001E\u0004";
 
-  static final int ASCII_ENCODATION = 0;
-  static final int C40_ENCODATION = 1;
-  static final int TEXT_ENCODATION = 2;
-  static final int X12_ENCODATION = 3;
-  static final int EDIFACT_ENCODATION = 4;
-  static final int BASE256_ENCODATION = 5;
+  public static final int ASCII_ENCODATION = 0;
+  public static final int C40_ENCODATION = 1;
+  public static final int TEXT_ENCODATION = 2;
+  public static final int X12_ENCODATION = 3;
+  public static final int EDIFACT_ENCODATION = 4;
+  public static final int BASE256_ENCODATION = 5;
+  public static final int DDDOC_ENCODATION = 6;
 
   private HighLevelEncoder() {
   }
@@ -139,7 +140,7 @@ public final class HighLevelEncoder {
    * @return the encoded message (the char values range from 0 to 255)
    */
   public static String encodeHighLevel(String msg) {
-    return encodeHighLevel(msg, SymbolShapeHint.FORCE_NONE, null, null);
+    return encodeHighLevel(msg, SymbolShapeHint.FORCE_NONE, null, null, ASCII_ENCODATION);
   }
 
   /**
@@ -151,55 +152,64 @@ public final class HighLevelEncoder {
    *                {@code SymbolShapeHint.FORCE_SQUARE} or {@code SymbolShapeHint.FORCE_RECTANGLE}.
    * @param minSize the minimum symbol size constraint or null for no constraint
    * @param maxSize the maximum symbol size constraint or null for no constraint
+   * @param encoding the encoding used for the message
    * @return the encoded message (the char values range from 0 to 255)
    */
   public static String encodeHighLevel(String msg,
-                                       SymbolShapeHint shape, 
-                                       Dimension minSize, 
-                                       Dimension maxSize) {
-    //the codewords 0..255 are encoded as Unicode characters
-    Encoder[] encoders = {
-        new ASCIIEncoder(), new C40Encoder(), new TextEncoder(), 
-        new X12Encoder(), new EdifactEncoder(),  new Base256Encoder()
-    };
+      SymbolShapeHint shape,
+      Dimension minSize,
+      Dimension maxSize,
+      int encoding) {
 
     EncoderContext context = new EncoderContext(msg);
     context.setSymbolShape(shape);
     context.setSizeConstraints(minSize, maxSize);
 
-    if (msg.startsWith(MACRO_05_HEADER) && msg.endsWith(MACRO_TRAILER)) {
-      context.writeCodeword(MACRO_05);
-      context.setSkipAtEnd(2);
-      context.pos += MACRO_05_HEADER.length();
-    } else if (msg.startsWith(MACRO_06_HEADER) && msg.endsWith(MACRO_TRAILER)) {
-      context.writeCodeword(MACRO_06);
-      context.setSkipAtEnd(2);
-      context.pos += MACRO_06_HEADER.length();
-    }
 
-    int encodingMode = ASCII_ENCODATION; //Default mode
-    while (context.hasMoreCharacters()) {
-      encoders[encodingMode].encode(context);
-      if (context.getNewEncoding() >= 0) {
-        encodingMode = context.getNewEncoding();
-        context.resetEncoderSignal();
+    if(encoding == DDDOC_ENCODATION){
+      DDDocEncoder ddDocEncoder = new DDDocEncoder();
+      ddDocEncoder.encode(context);
+    } else {
+      //the codewords 0..255 are encoded as Unicode characters
+      Encoder[] encoders = {
+          new ASCIIEncoder(), new C40Encoder(), new TextEncoder(),
+          new X12Encoder(), new EdifactEncoder(),  new Base256Encoder()
+      };
+
+
+      if (msg.startsWith(MACRO_05_HEADER) && msg.endsWith(MACRO_TRAILER)) {
+        context.writeCodeword(MACRO_05);
+        context.setSkipAtEnd(2);
+        context.pos += MACRO_05_HEADER.length();
+      } else if (msg.startsWith(MACRO_06_HEADER) && msg.endsWith(MACRO_TRAILER)) {
+        context.writeCodeword(MACRO_06);
+        context.setSkipAtEnd(2);
+        context.pos += MACRO_06_HEADER.length();
       }
-    }
-    int len = context.getCodewordCount();
-    context.updateSymbolInfo();
-    int capacity = context.getSymbolInfo().getDataCapacity();
-    if (len < capacity) {
-      if (encodingMode != ASCII_ENCODATION && encodingMode != BASE256_ENCODATION) {
-        context.writeCodeword('\u00fe'); //Unlatch (254)
+      int encodingMode = encoding; //Default mode
+      while (context.hasMoreCharacters()) {
+        encoders[encodingMode].encode(context);
+        if (context.getNewEncoding() >= 0) {
+          encodingMode = context.getNewEncoding();
+          context.resetEncoderSignal();
+        }
       }
-    }
-    //Padding
-    StringBuilder codewords = context.getCodewords();
-    if (codewords.length() < capacity) {
-      codewords.append(PAD);
-    }
-    while (codewords.length() < capacity) {
-      codewords.append(randomize253State(PAD, codewords.length() + 1));
+      int len = context.getCodewordCount();
+      context.updateSymbolInfo();
+      int capacity = context.getSymbolInfo().getDataCapacity();
+      if (len < capacity) {
+        if (encodingMode != ASCII_ENCODATION && encodingMode != BASE256_ENCODATION) {
+          context.writeCodeword('\u00fe'); //Unlatch (254)
+        }
+      }
+      //Padding
+      StringBuilder codewords = context.getCodewords();
+      if (codewords.length() < capacity) {
+        codewords.append(PAD);
+      }
+      while (codewords.length() < capacity) {
+        codewords.append(randomize253State(PAD, codewords.length() + 1));
+      }
     }
 
     return context.getCodewords().toString();


### PR DESCRIPTION
2D-Doc is a specific usage of Datamatrix defined in France, see [1] for more information.

There is no issue to read 2D-Doc with zxing.

The only issue is about generation because 2D-Doc only uses ASCII encoding and does not optimize the encoding.

This patch:
* modify HighLevelEncoder to allow bypass of encodation optimization
* provide a new specific writer: DDDocWriter
* provide a 2D-Doc encoder
* provide some local changes to glue all the stuff

This is my first attempt with zxing, so I am waiting for your feedbacks to improve this proposal.

KR,
Guillaume

[1] https://ants.gouv.fr/content/download/516/5665/version/4/file/ANTS_2D-Doc_CABSpec_v2.0.1_erratum.pdf
in french, sorry
