### PR TITLE
Fixed coding bug in QRcode encoding mask penalty rule #3 calculation

### DIFF
--- a/core/src/main/java/com/google/zxing/qrcode/encoder/MaskUtil.java
+++ b/core/src/main/java/com/google/zxing/qrcode/encoder/MaskUtil.java
@@ -107,6 +107,9 @@ final class MaskUtil {
       if (i >= 0 && i < rowArray.length && rowArray[i] == 1) {
         return false;
       }
+      if(i<0 || i >= rowArray.length){
+        return false;
+      }
     }
     return true;
   }
@@ -114,6 +117,9 @@ final class MaskUtil {
   private static boolean isWhiteVertical(byte[][] array, int col, int from, int to) {
     for (int i = from; i < to; i++) {
       if (i >= 0 && i < array.length && array[i][col] == 1) {
+        return false;
+      }
+      if(i<0 || i >= array.length){
         return false;
       }
     }


### PR DESCRIPTION
A bug exists in the way zxing calculates the mask to apply during QR code generation.

Eight masks have to be tested and the one with the lowest penalty is chosen to be applied to the QR code being created. Each mask is scored on four criteria (rules), and rule 3 gives a penalty based on a particular sequence of black and white squares being present in the code. 

zxing uses two helper functions ```isWhiteHorizontal``` and ```isWhiteVertical```  to test if a given range of cells are all white (=0). 

However, a bug in the functions makes them return ```true``` even if the range of cells is out of range. This results often in higher rule 3 penalty values and can end up with a QR code choosing a suboptimal masking pattern.  