### PR TITLE
Use StringWriter to prevent race condition in println

### DIFF
--- a/javase/src/main/java/com/google/zxing/client/j2se/DecodeWorker.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/DecodeWorker.java
@@ -34,6 +34,7 @@ import com.google.zxing.multi.MultipleBarcodeReader;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -149,21 +150,30 @@ final class DecodeWorker implements Callable<Integer> {
     if (config.brief) {
       System.out.println(uri + ": Success");
     } else {
-      for (Result result : results) {
+      StringWriter output = new StringWriter();
+      for (int resultIndex = 0; resultIndex < results.length; resultIndex++) {
+        Result result = results[resultIndex];
         ParsedResult parsedResult = ResultParser.parseResult(result);
-        System.out.println(uri +
+        output.write(uri +
             " (format: " + result.getBarcodeFormat() +
             ", type: " + parsedResult.getType() + "):\n" +
             "Raw result:\n" +
             result.getText() + "\n" +
             "Parsed result:\n" +
-            parsedResult.getDisplayResult());
-        System.out.println("Found " + result.getResultPoints().length + " result points.");
-        for (int i = 0; i < result.getResultPoints().length; i++) {
-          ResultPoint rp = result.getResultPoints()[i];
-          System.out.println("  Point " + i + ": (" + rp.getX() + ',' + rp.getY() + ')');
+            parsedResult.getDisplayResult() + "\n");
+        output.write("Found " + result.getResultPoints().length + " result points.\n");
+        for (int pointIndex = 0; pointIndex < result.getResultPoints().length; pointIndex++) {
+          ResultPoint rp = result.getResultPoints()[pointIndex];
+          output.write("  Point " + pointIndex + ": (" + rp.getX() + ',' + rp.getY() + ')');
+          if (pointIndex != result.getResultPoints().length - 1) {
+            output.write('\n');
+          }
+        }
+        if (resultIndex != results.length - 1) {
+          output.write('\n');
         }
       }
+      System.out.println(output.toString());
     }
 
     return results;


### PR DESCRIPTION
@srowen This pull request resolves a race condition seen in printing output in the command line runner. I'm not entirely sure why this occurs, but presumably the multithreaded execution of the command line runner can cause the `println` calls to be executed out of order. This is apparently something that [can happen with println in multithreaded execution](http://stackoverflow.com/questions/19460987/why-is-system-out-prinln-out-of-order).

I found this occurs in two cases in my OS X environment. The first was when one of the input files is a symlink to another of input files. The second was when the files had very recently been written to disk by another program. I'm guessing in both cases, the data is already in memory, making the race condition more likely. The goofy output looks like this:
```
file:///Users/lucaswiman/opensource/zxing/javase/text1.png (format: QR_CODE, type: TEXT):
Raw result:
text1
Parsed result:
text1
Found 3 result points.
  Point 0: (44.0,156.0)
file:///Users/lucaswiman/opensource/zxing/javase/text1-symlink.png (format: QR_CODE, type: TEXT):
Raw result:
text1
Parsed result:
text1
  Point 1: (44.0,44.0)
Found 3 result points.
  Point 2: (156.0,44.0)
  Point 0: (44.0,156.0)
  Point 1: (44.0,44.0)
  Point 2: (156.0,44.0)

Decoded 2 files out of 2 successfully (100%)
```
Note that the points from the first file were printed while printing the points from the second file.

In order to avoid the race condition, I wrote the output using a `StringWriter` for each file, printing the output for each file when it's ready. My understanding is that `System.out.println` synchronizes the output buffer, so this should be a safe operation. 

## Testing
I tested this out with the following two runs below. The example files were this QR code, and a symlink to it:
![text1](https://cloud.githubusercontent.com/assets/123110/13041668/2e645404-d36e-11e5-9ac8-1e78fdd686a6.png)

### This branch
```
(for i in `seq 1 10`;
do
    java -Dapple.awt.UIElement=true -jar target/javase-3.2.2-SNAPSHOT-jar-with-dependencies.jar text1.png text1-symlink.png --multi
done) > /tmp/patched.output
```
### Compiled from 1fbefcac3146bf61efadb2d5da428b0f559d630c
```
(for i in `seq 1 10`;
do
    java -Dapple.awt.UIElement=true -jar target/javase-3.2.2-SNAPSHOT-jar-with-dependencies.jar text1.png text1-symlink.png --multi
done) > /tmp/1fbefcac3146bf61efadb2d5da428b0f559d630c.output
```

The output from those runs can be seen in [this gist.](https://gist.github.com/lucaswiman/e88775bc8b29c439258a)