### PR TITLE
cleaned up the new aztec decoder by @iSDP referenced in issue #381

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -338,6 +338,8 @@ public final class Decoder {
     for (int i = 0; i < 8; i++) {
       if (array[start + i]) {
         b |= 1 << (7 - i);
+      } else {
+        throw new IndexOutOfBoundsException();
       }
     }
     return b;

--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -336,16 +336,18 @@ public final class Decoder {
   private static byte boolsToByte(final boolean[] array, final int start) {
     byte b = 0;
     for (int i = 0; i < 8; i++) {
-      if (array[start + i])
+      if (array[start + i]) {
         b |= 1 << (7 - i);
+      }
     }
     return b;
   }
 
   public static byte[] convertBoolArrayToByteArray(boolean[] boolArr) {
     byte[] byteArr = new byte[boolArr.length / 8];
-    for (int i = 0; i < byteArr.length; i++)
+    for (int i = 0; i < byteArr.length; i++) {
       byteArr[i] = boolsToByte(boolArr, 8 * i);
+    }
     return byteArr;
   }
 

--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -75,8 +75,9 @@ public final class Decoder {
     BitMatrix matrix = detectorResult.getBits();
     boolean[] rawbits = extractBits(matrix);
     boolean[] correctedBits = correctBits(rawbits);
+    byte[] rawBytes = convertBoolArrayToByteArray(correctedBits);
     String result = getEncodedData(correctedBits);
-    return new DecoderResult(null, result, null, null);
+    return new DecoderResult(rawBytes, result, null, null);
   }
 
   // This method is used for testing the high-level encoder
@@ -330,6 +331,22 @@ public final class Decoder {
       }
     }
     return res;
+  }
+
+  private static byte boolsToByte(final boolean[] array, final int start) {
+    byte b = 0;
+    for (int i = 0; i < 8; i++) {
+      if (array[start + i])
+        b |= 1 << (7 - i);
+    }
+    return b;
+  }
+
+  public static byte[] convertBoolArrayToByteArray(boolean[] boolArr) {
+    byte[] byteArr = new byte[boolArr.length / 8];
+    for (int i = 0; i < byteArr.length; i++)
+      byteArr[i] = boolsToByte(boolArr, 8 * i);
+    return byteArr;
   }
 
   private static int totalBitsInLayer(int layers, boolean compact) {


### PR DESCRIPTION
A while back @iSDP complained that the Aztec decoder does not return raw bytes like eg. the QR decoder. He made a PR [#389](https://github.com/zxing/zxing/pull/389), but it was rejected due to formatting issues.

I'd really like for this to work. Many Aztec barcodes don't store string data but compressed zlib streams, which get corrupted when turned into strings. The raw bytes would help.

I have not written any of the lines in this PR, only reformatted @iSDP's work to match the repo's conventions. I hope this is ok.