### PR TITLE
Aztec decoder returns raw bytes

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -347,7 +347,7 @@ public final class Decoder {
   /**
    * Packs a bit array into bytes, most significant bit first
    */
-  public static byte[] convertBoolArrayToByteArray(boolean[] boolArr) {
+  static byte[] convertBoolArrayToByteArray(boolean[] boolArr) {
     byte[] byteArr = new byte[(boolArr.length + 7) / 8];
     for (int i = 0; i < byteArr.length; i++) {
       byteArr[i] = readByte(boolArr, 8 * i);

--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -75,8 +75,9 @@ public final class Decoder {
     BitMatrix matrix = detectorResult.getBits();
     boolean[] rawbits = extractBits(matrix);
     boolean[] correctedBits = correctBits(rawbits);
+    byte[] rawBytes = convertBoolArrayToByteArray(correctedBits);
     String result = getEncodedData(correctedBits);
-    return new DecoderResult(null, result, null, null);
+    return new DecoderResult(rawBytes, result, null, null);
   }
 
   // This method is used for testing the high-level encoder
@@ -330,6 +331,28 @@ public final class Decoder {
       }
     }
     return res;
+  }
+
+  /**
+   * Reads a code of length 8 in an array of bits, padding with zeros
+   */
+  private static byte readByte(boolean[] rawbits, int startIndex) {
+    int n = rawbits.length - startIndex;
+    if (n >= 8) {
+      return (byte) readCode(rawbits, startIndex, 8);
+    }
+    return (byte) (readCode(rawbits, startIndex, n) << (8 - n));
+  }
+
+  /**
+   * Packs a bit array into bytes, most significant bit first
+   */
+  public static byte[] convertBoolArrayToByteArray(boolean[] boolArr) {
+    byte[] byteArr = new byte[(boolArr.length + 7) / 8];
+    for (int i = 0; i < byteArr.length; i++) {
+      byteArr[i] = readByte(boolArr, 8 * i);
+    }
+    return byteArr;
   }
 
   private static int totalBitsInLayer(int layers, boolean compact) {

--- a/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
@@ -106,35 +106,28 @@ public final class DecoderTest extends Assert {
     new Decoder().decode(r);
   }
 
-  private static void assertEqualByteArrays(byte[] b1, byte[] b2) {
-    assertEquals(b1.length, b2.length);
-    for (int i = 0; i < b1.length; i++) {
-      assertEquals(b1[i], b2[i]);
-    }
-  }
-
   @Test
   public void testRawBytes() {
-    boolean bool0[] = {};
-    boolean bool1[] = { true };
-    boolean bool7[] = { true, false, true, false, true, false, true };
-    boolean bool8[] = { true, false, true, false, true, false, true, false };
-    boolean bool9[] = { true, false, true, false, true, false, true, false,
+    boolean[] bool0 = {};
+    boolean[] bool1 = { true };
+    boolean[] bool7 = { true, false, true, false, true, false, true };
+    boolean[] bool8 = { true, false, true, false, true, false, true, false };
+    boolean[] bool9 = { true, false, true, false, true, false, true, false,
                         true };
-    boolean bool16[] = { false, true, true, false, false, false, true, true,
+    boolean[] bool16 = { false, true, true, false, false, false, true, true,
                          true, true, false, false, false, false, false, true };
-    byte byte0[] = {};
-    byte byte1[] = { -128 };
-    byte byte7[] = { -86 };
-    byte byte8[] = { -86 };
-    byte byte9[] = { -86, -128 };
-    byte byte16[] = { 99, -63 };
+    byte[] byte0 = {};
+    byte[] byte1 = { -128 };
+    byte[] byte7 = { -86 };
+    byte[] byte8 = { -86 };
+    byte[] byte9 = { -86, -128 };
+    byte[] byte16 = { 99, -63 };
 
-    assertEqualByteArrays(byte0, Decoder.convertBoolArrayToByteArray(bool0));
-    assertEqualByteArrays(byte1, Decoder.convertBoolArrayToByteArray(bool1));
-    assertEqualByteArrays(byte7, Decoder.convertBoolArrayToByteArray(bool7));
-    assertEqualByteArrays(byte8, Decoder.convertBoolArrayToByteArray(bool8));
-    assertEqualByteArrays(byte9, Decoder.convertBoolArrayToByteArray(bool9));
-    assertEqualByteArrays(byte16, Decoder.convertBoolArrayToByteArray(bool16));
+    assertArrayEquals(byte0, Decoder.convertBoolArrayToByteArray(bool0));
+    assertArrayEquals(byte1, Decoder.convertBoolArrayToByteArray(bool1));
+    assertArrayEquals(byte7, Decoder.convertBoolArrayToByteArray(bool7));
+    assertArrayEquals(byte8, Decoder.convertBoolArrayToByteArray(bool8));
+    assertArrayEquals(byte9, Decoder.convertBoolArrayToByteArray(bool9));
+    assertArrayEquals(byte16, Decoder.convertBoolArrayToByteArray(bool16));
   }
 }

--- a/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
@@ -20,8 +20,9 @@ import com.google.zxing.ResultPoint;
 import com.google.zxing.aztec.AztecDetectorResult;
 import com.google.zxing.common.BitMatrix;
 import org.junit.Test;
+import org.junit.Assert;
 
-public final class DecoderTest {
+public final class DecoderTest extends Assert {
 
   private static final ResultPoint[] NO_POINTS = new ResultPoint[0];
 
@@ -105,4 +106,35 @@ public final class DecoderTest {
     new Decoder().decode(r);
   }
 
+  private static void assertEqualByteArrays(byte[] b1, byte[] b2) {
+    assertEquals(b1.length, b2.length);
+    for (int i = 0; i < b1.length; i++) {
+      assertEquals(b1[i], b2[i]);
+    }
+  }
+
+  @Test
+  public void testRawBytes() {
+    boolean bool0[] = {};
+    boolean bool1[] = { true };
+    boolean bool7[] = { true, false, true, false, true, false, true };
+    boolean bool8[] = { true, false, true, false, true, false, true, false };
+    boolean bool9[] = { true, false, true, false, true, false, true, false,
+                        true };
+    boolean bool16[] = { false, true, true, false, false, false, true, true,
+                         true, true, false, false, false, false, false, true };
+    byte byte0[] = {};
+    byte byte1[] = { -128 };
+    byte byte7[] = { -86 };
+    byte byte8[] = { -86 };
+    byte byte9[] = { -86, -128 };
+    byte byte16[] = { 99, -63 };
+
+    assertEqualByteArrays(byte0, Decoder.convertBoolArrayToByteArray(bool0));
+    assertEqualByteArrays(byte1, Decoder.convertBoolArrayToByteArray(bool1));
+    assertEqualByteArrays(byte7, Decoder.convertBoolArrayToByteArray(bool7));
+    assertEqualByteArrays(byte8, Decoder.convertBoolArrayToByteArray(bool8));
+    assertEqualByteArrays(byte9, Decoder.convertBoolArrayToByteArray(bool9));
+    assertEqualByteArrays(byte16, Decoder.convertBoolArrayToByteArray(bool16));
+  }
 }


### PR DESCRIPTION
The Aztec decoder now packs the code bits into bytes and returns them as "raw bytes", even though the error correction codes and stuffing have been already removed.  Also added a couple of test cases for the byte-packing function.  This fixes issue #381.

I hereby grant everyone the right to use and distribute this contribution under the same terms as the original program.