### PR TITLE
I've seen some codes with the type set to WPA2

### DIFF
--- a/android/src/com/google/zxing/client/android/wifi/NetworkType.java
+++ b/android/src/com/google/zxing/client/android/wifi/NetworkType.java
@@ -26,7 +26,8 @@ enum NetworkType {
     if (networkTypeString == null) {
       return NO_PASSWORD;
     }
-    if ("WPA".equals(networkTypeString)) {
+    if ("WPA".equals(networkTypeString) ||
+        "WPA2".equals(networkTypeString)) {
       return WPA;
     }
     if ("WEP".equals(networkTypeString)) {


### PR DESCRIPTION
Make zxing recognize WIFI qrcodes with the type field set to WPA2 as WPA.