### PR TITLE
enterprise wifi support, requires android version 18

### DIFF
--- a/core/src/main/java/com/google/zxing/client/result/WifiParsedResult.java
+++ b/core/src/main/java/com/google/zxing/client/result/WifiParsedResult.java
@@ -27,6 +27,9 @@ public final class WifiParsedResult extends ParsedResult {
   private final String networkEncryption;
   private final String password;
   private final boolean hidden;
+  //enterprise wpa2 enhancement
+  private final String username;
+  private final String eapauth; //phase2 auth/inner auth
 
   public WifiParsedResult(String networkEncryption, String ssid, String password) {
     this(networkEncryption, ssid, password, false);
@@ -38,6 +41,18 @@ public final class WifiParsedResult extends ParsedResult {
     this.networkEncryption = networkEncryption;
     this.password = password;
     this.hidden = hidden;
+    this.username = "";
+    this.eapauth = "";
+  }
+
+  public WifiParsedResult(String networkEncryption, String eapauth, String ssid, String username, String password, boolean hidden) {
+    super(ParsedResultType.WIFI);
+    this.ssid = ssid;
+    this.networkEncryption = networkEncryption;
+    this.password = password;
+    this.hidden = hidden;
+    this.username = username;
+    this.eapauth = eapauth; //phase2Auth
   }
 
   public String getSsid() {
@@ -46,6 +61,14 @@ public final class WifiParsedResult extends ParsedResult {
 
   public String getNetworkEncryption() {
     return networkEncryption;
+  }
+
+  public String getEAPauth() {
+    return eapauth;
+  }
+
+  public String getUsername() {
+    return username;
   }
 
   public String getPassword() {

--- a/core/src/main/java/com/google/zxing/client/result/WifiResultParser.java
+++ b/core/src/main/java/com/google/zxing/client/result/WifiResultParser.java
@@ -25,6 +25,9 @@ import com.google.zxing.Result;
  *
  * <p>The fields can appear in any order. Only "S:" is required.</p>
  *
+ * <p>wpa2 Enterprise Format: WIFI:S:eduroam;U:username;P:password;E:PEAP;PH:MS-CHAPv2;;</p>
+ *
+ *
  * @author Vikram Aggarwal
  * @author Sean Owen
  */
@@ -45,7 +48,17 @@ public final class WifiResultParser extends ResultParser {
     if (type == null) {
       type = "nopass";
     }
+    String username = matchSinglePrefixedField("U:", rawText, ';', false);
+    String eap = matchSinglePrefixedField("E:", rawText, ';', false);
+    String eapauth = matchSinglePrefixedField("PH:", rawText, ';', false);
+
     boolean hidden = Boolean.parseBoolean(matchSinglePrefixedField("H:", rawText, ';', false));
+
+    if (eap != null && !eap.isEmpty()) {
+      //enterprise wifi
+      return new WifiParsedResult(eap, ssid, eapauth, username, pass, hidden);
+    }
+    //non enterprise
     return new WifiParsedResult(type, ssid, pass, hidden);
   }
 }


### PR DESCRIPTION
Hello There
Support for WPA2 Enterprise Wifi Networks.
Requires Android Version 18.
But xzing bases an earlier Version, so this does NOT compile!
