### PR TITLE
removed 'continuous-video' mode

### DIFF
--- a/android-core/src/main/java/com/google/zxing/client/android/camera/CameraConfigurationUtils.java
+++ b/android-core/src/main/java/com/google/zxing/client/android/camera/CameraConfigurationUtils.java
@@ -70,7 +70,6 @@ public final class CameraConfigurationUtils {
         focusMode = findSettableValue("focus mode",
                                       supportedFocusModes,
                                       Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE,
-                                      Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO,
                                       Camera.Parameters.FOCUS_MODE_AUTO);
       }
     }


### PR DESCRIPTION
I found it better to not use this mode becouse it sets focus on start and then never tweak it again later. 

It is returned in AutofocusManager as currentFocusMode and maks useAutoFocus == false.

For me it worked better if currentFocusMode is 'auto' than 'continous-video' becouse it start autofocusing by focus() and autoFocusAgainLater() by AutoFocusManager. 

"... The focus position is locked after autoFocus call ...."
source:
https://developer.android.com/reference/android/hardware/Camera.Parameters.html#FOCUS_MODE_CONTINUOUS_VIDEO