### PR TITLE
Updated QZXing's URL (port to Qt framework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ library implemented in Java, with ports to other languages.
 
 | Module                                                          | Description
 | --------------------------------------------------------------- | -----------
-| [QZXing](https://sourceforge.net/projects/qzxing)               | port to Qt framework
+| [QZXing](https://github.com/ftylitak/qzxing)                    | port to Qt framework
 | [zxing-cpp](https://github.com/glassechidna/zxing-cpp)          | port to C++ (forked from the [deprecated official C++ port](https://github.com/zxing/zxing/tree/00f634024ceeee591f54e6984ea7dd666fab22ae/cpp))
 | [zxing_cpp.rb](https://github.com/glassechidna/zxing_cpp.rb)    | bindings for Ruby (not just JRuby), powered by [zxing-cpp](https://github.com/glassechidna/zxing-cpp)
 | [python-zxing](https://github.com/oostendo/python-zxing)        | bindings for Python


### PR DESCRIPTION
I would like to request the update of QZXing's project repository URL in order to keep the readme file up-to-date. 

Previous location: [SourceForge](https://sourceforge.net/projects/qzxing/)
New location: [GitHub](https://github.com/ftylitak/qzxing)