### PR TITLE
Fix two typos in Javadocs

### DIFF
--- a/core/src/main/java/com/google/zxing/common/reedsolomon/ReedSolomonEncoder.java
+++ b/core/src/main/java/com/google/zxing/common/reedsolomon/ReedSolomonEncoder.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * <p>Implements Reed-Solomon enbcoding, as the name implies.</p>
+ * <p>Implements Reed-Solomon encoding, as the name implies.</p>
  *
  * @author Sean Owen
  * @author William Rucklidge

--- a/zxing.appspot.com/src/main/java/com/google/zxing/web/generator/client/ContactInfoGenerator.java
+++ b/zxing.appspot.com/src/main/java/com/google/zxing/web/generator/client/ContactInfoGenerator.java
@@ -24,7 +24,7 @@ import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 
 /**
- * A Generator for contact informations, output is in MeCard format.
+ * A Generator for contact information, output is in MeCard format.
  * 
  * @author Yohann Coppel
  * @author Sean Owen


### PR DESCRIPTION
I found two typos in the Javadocs and fixed them