### PR TITLE
Correct size of array in ITFWriter

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/ITFWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/ITFWriter.java
@@ -61,7 +61,7 @@ public final class ITFWriter extends OneDimensionalCodeWriter {
     for (int i = 0; i < length; i += 2) {
       int one = Character.digit(contents.charAt(i), 10);
       int two = Character.digit(contents.charAt(i + 1), 10);
-      int[] encoding = new int[18];
+      int[] encoding = new int[10];
       for (int j = 0; j < 5; j++) {
         encoding[2 * j] = ITFReader.PATTERNS[one][j];
         encoding[2 * j + 1] = ITFReader.PATTERNS[two][j];


### PR DESCRIPTION
The intermediate array only needs to be 10 ints long, not 18. The max value for `j` is 4, so `2 * 4 + 1 = 9`.