### PR TITLE
Update ZXing.NET project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ library implemented in Java, with ports to other languages.
 | [zxing_cpp.rb](https://github.com/glassechidna/zxing_cpp.rb)    | bindings for Ruby (not just JRuby), powered by [zxing-cpp](https://github.com/glassechidna/zxing-cpp)
 | [jsqrcode](https://github.com/LazarSoft/jsqrcode)               | port to JavaScript
 | [python-zxing](https://github.com/oostendo/python-zxing)        | bindings for Python
-| [ZXing .NET](https://zxingnet.codeplex.com/)                     | port to .NET and C#, and related Windows platform
+| [ZXing .NET](https://github.com/micjahn/ZXing.Net)                     | port to .NET and C#, and related Windows platform
 | [php-qrcode-detector-decoder](https://github.com/khanamiryan/php-qrcode-detector-decoder)                     | port to PHP
 | [ZXing Delphi](https://github.com/Spelt/ZXing.Delphi)          |  Port to native Delphi object pascal, targeted at Firemonkey compatible devices (IOS/Android/Win/OSX) and VCL.
 


### PR DESCRIPTION
The ZXing.NET project is originally hosted on CodePlex, but Microsoft shut down the site recently, then the developer moved it to GitHub. So I update the link.