### PR TITLE
Drop debugging code from UPCEWriter

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
@@ -35,11 +35,6 @@ public final class UPCEWriter extends UPCEANWriter {
       (7 * 6) + // bars
       6; // end guard
 
-  public static void main(String[] args) throws Exception {
-    BitMatrix bm = new UPCEWriter().encode("12345670", BarcodeFormat.UPC_E, 200, 100, null);
-    System.out.println(bm);
-  }
-
   @Override
   public BitMatrix encode(String contents,
                           BarcodeFormat format,


### PR DESCRIPTION
Looks like some debugging code got left in the UPCEWriter class. Presumably there's no reason to keep it in the codebase.