### PR TITLE
Fixed Wifi mangager memory leak on devices < N

### DIFF
--- a/android/src/com/google/zxing/client/android/result/WifiResultHandler.java
+++ b/android/src/com/google/zxing/client/android/result/WifiResultHandler.java
@@ -61,7 +61,7 @@ public final class WifiResultHandler extends ResultHandler {
   public void handleButtonPress(int index) {
     if (index == 0) {
       WifiParsedResult wifiResult = (WifiParsedResult) getResult();
-      WifiManager wifiManager = (WifiManager) getActivity().getSystemService(Context.WIFI_SERVICE);
+      WifiManager wifiManager = (WifiManager) getActivity().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
       if (wifiManager == null) {
         Log.w(TAG, "No WifiManager available from device");
         return;


### PR DESCRIPTION
AndroidStudio reported the error:
Error: The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing to .getApplicationContext()  [WifiManagerLeak]