### PR TITLE
Implement support for WPA2 Enterprise (EAP)

### DIFF
--- a/android/src/com/google/zxing/client/android/wifi/NetworkType.java
+++ b/android/src/com/google/zxing/client/android/wifi/NetworkType.java
@@ -20,7 +20,8 @@ enum NetworkType {
 
   WEP,
   WPA,
-  NO_PASSWORD;
+  NO_PASSWORD,
+  WPA2_EAP;
 
   static NetworkType forIntentValue(String networkTypeString) {
     if (networkTypeString == null) {
@@ -30,6 +31,8 @@ enum NetworkType {
       case "WPA":
       case "WPA2":
         return WPA;
+      case "WPA2-EAP":
+        return WPA2_EAP;
       case "WEP":
         return WEP;
       case "nopass":

--- a/core/src/main/java/com/google/zxing/client/result/WifiParsedResult.java
+++ b/core/src/main/java/com/google/zxing/client/result/WifiParsedResult.java
@@ -27,17 +27,29 @@ public final class WifiParsedResult extends ParsedResult {
   private final String networkEncryption;
   private final String password;
   private final boolean hidden;
+  private final String identity;
+  private final String anonymousIdentity;
+  private final String eapMethod;
+  private final String phase2Method;
 
   public WifiParsedResult(String networkEncryption, String ssid, String password) {
     this(networkEncryption, ssid, password, false);
   }
 
   public WifiParsedResult(String networkEncryption, String ssid, String password, boolean hidden) {
+    this(networkEncryption, ssid, password, hidden, null, null, null, null);
+  }
+
+  public WifiParsedResult(String networkEncryption, String ssid, String password, boolean hidden, String identity, String anonymousIdentity, String eapMethod, String phase2Method) {
     super(ParsedResultType.WIFI);
     this.ssid = ssid;
     this.networkEncryption = networkEncryption;
     this.password = password;
     this.hidden = hidden;
+    this.identity = identity;
+    this.anonymousIdentity = anonymousIdentity;
+    this.eapMethod = eapMethod;
+    this.phase2Method = phase2Method;
   }
 
   public String getSsid() {
@@ -54,6 +66,22 @@ public final class WifiParsedResult extends ParsedResult {
 
   public boolean isHidden() {
     return hidden;
+  }
+
+  public String getIdentity() {
+    return identity;
+  }
+
+  public String getAnonymousIdentity() {
+    return anonymousIdentity;
+  }
+
+  public String getEapMethod() {
+    return eapMethod;
+  }
+
+  public String getPhase2Method() {
+    return phase2Method;
   }
 
   @Override

--- a/core/src/main/java/com/google/zxing/client/result/WifiResultParser.java
+++ b/core/src/main/java/com/google/zxing/client/result/WifiResultParser.java
@@ -23,10 +23,17 @@ import com.google.zxing.Result;
  *
  * <p>{@code WIFI:T:[network type];S:[network SSID];P:[network password];H:[hidden?];;}</p>
  *
+ * <p>For WPA2 enterprise (EAP), strings will be of the form:</p>
+ *
+ * <p>{@code WIFI:T:WPA2-EAP;S:[network SSID];H:[hidden?];E:[EAP method];H:[Phase 2 method];A:[anonymous identity];I:[username];P:[password];;}</p>
+ *
+ * <p>"EAP method" can e.g. be "TTLS" or "PWD" or one of the other fields in <a href="https://developer.android.com/reference/android/net/wifi/WifiEnterpriseConfig.Eap.html">WifiEnterpriseConfig.Eap</a> and "Phase 2 method" can e.g. be "MSCHAPV2" or any of the other fields in <a href="https://developer.android.com/reference/android/net/wifi/WifiEnterpriseConfig.Phase2.html">WifiEnterpriseConfig.Phase2</a></p>
+ *
  * <p>The fields can appear in any order. Only "S:" is required.</p>
  *
  * @author Vikram Aggarwal
  * @author Sean Owen
+ * @author Steffen Kieß
  */
 public final class WifiResultParser extends ResultParser {
 
@@ -36,6 +43,7 @@ public final class WifiResultParser extends ResultParser {
     if (!rawText.startsWith("WIFI:")) {
       return null;
     }
+    rawText = rawText.substring("WIFI:".length());
     String ssid = matchSinglePrefixedField("S:", rawText, ';', false);
     if (ssid == null || ssid.isEmpty()) {
       return null;
@@ -46,6 +54,10 @@ public final class WifiResultParser extends ResultParser {
       type = "nopass";
     }
     boolean hidden = Boolean.parseBoolean(matchSinglePrefixedField("H:", rawText, ';', false));
-    return new WifiParsedResult(type, ssid, pass, hidden);
+    String identity = matchSinglePrefixedField("I:", rawText, ';', false);
+    String anonymousIdentity = matchSinglePrefixedField("A:", rawText, ';', false);
+    String eapMethod = matchSinglePrefixedField("E:", rawText, ';', false);
+    String phase2Method = matchSinglePrefixedField("H:", rawText, ';', false);
+    return new WifiParsedResult(type, ssid, pass, hidden, identity, anonymousIdentity, eapMethod, phase2Method);
   }
 }


### PR DESCRIPTION
This adds support for parsing QR codes which contain information about an WPA2 enterprise (EAP) network.

For WPA2 enterprise, strings will be of the form:
WIFI:T:WPA2-EAP;S:[network SSID];H:[hidden?];E:[EAP method];PH2:[Phase 2 method];AI:[anonymous identity];I:[username];P:[password];;
The "EAP method" can e.g. be "TTLS" or "PWD" or one of the other fields in [WifiEnterpriseConfig.Eap ](https://developer.android.com/reference/android/net/wifi/WifiEnterpriseConfig.Eap.html) and "Phase 2 method" can e.g. be "MSCHAPV2" or any of the other fields in [WifiEnterpriseConfig.Phase2](https://developer.android.com/reference/android/net/wifi/WifiEnterpriseConfig.Phase2.html)

An example would be:

    WIFI:S:eduroam;T:WPA2-EAP;AI:anonymous@uni-stuttgart.de;I:username@uni-stuttgart.de;P:password;E:PEAP;PH2:MSCHAPV2;;