### PR TITLE
Updated php-zxing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ library implemented in Java, with ports to other languages.
 | [php-qrcode-detector-decoder](https://github.com/khanamiryan/php-qrcode-detector-decoder)                     | port to PHP
 | [ZXing Delphi](https://github.com/Spelt/ZXing.Delphi)          |  Port to native Delphi object pascal, targeted at Firemonkey compatible devices (IOS/Android/Win/OSX) and VCL.
 | [ZXingObjC](https://github.com/TheLevelUp/ZXingObjC)            | Port to Objective-C
+| [php-zxing](https://github.com/dsiddharth2/php-zxing)           | PHP wrapper to Zxing Java library
 
 
 ### Other related third-party open source projects


### PR DESCRIPTION
Added a https://github.com/dsiddharth2/php-zxing link to ZXing-based third-party open source projects area.