### PR TITLE
Using 'zxing' prefix for all generated artifacts

### DIFF
--- a/android-core/pom.xml
+++ b/android-core/pom.xml
@@ -16,9 +16,7 @@
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <artifactId>android-core</artifactId>
-  <version>3.3.3-SNAPSHOT</version>
+  <artifactId>zxing-android-core</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/android-integration/pom.xml
+++ b/android-integration/pom.xml
@@ -16,9 +16,7 @@
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <artifactId>android-integration</artifactId>
-  <version>3.3.3-SNAPSHOT</version>
+  <artifactId>zxing-android-integration</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -17,18 +17,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>android</artifactId>
+  <artifactId>zxing-android</artifactId>
   <version>4.7.7</version>
   <packaging>apk</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.google.zxing</groupId>
-      <artifactId>core</artifactId>
+      <artifactId>zxing-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.zxing</groupId>
-      <artifactId>android-core</artifactId>
+      <artifactId>zxing-android-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.android</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,9 +16,7 @@
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <artifactId>core</artifactId>
-  <version>3.3.3-SNAPSHOT</version>
+  <artifactId>zxing-core</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -60,6 +58,5 @@
       </build>
     </profile>
   </profiles>
-  
 </project>
 

--- a/javase/pom.xml
+++ b/javase/pom.xml
@@ -16,15 +16,13 @@
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
-  <artifactId>javase</artifactId>
-  <version>3.3.3-SNAPSHOT</version>
+  <artifactId>zxing-javase</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.google.zxing</groupId>
-      <artifactId>core</artifactId>
+      <artifactId>zxing-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,26 +41,28 @@
         <version>${slf4j.version}</version>
         <scope>runtime</scope>
       </dependency>
+
       <dependency>
         <groupId>com.google.zxing</groupId>
-        <artifactId>core</artifactId>
+        <artifactId>zxing-core</artifactId>
         <version>${zxing.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.zxing</groupId>
-        <artifactId>android-core</artifactId>
+        <artifactId>zxing-android-core</artifactId>
         <version>${zxing.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.zxing</groupId>
-        <artifactId>android-integration</artifactId>
+        <artifactId>zxing-android-integration</artifactId>
         <version>${zxing.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.zxing</groupId>
-        <artifactId>javase</artifactId>
+        <artifactId>zxing-javase</artifactId>
         <version>${zxing.version}</version>
       </dependency>
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/zxing.appspot.com/pom.xml
+++ b/zxing.appspot.com/pom.xml
@@ -16,9 +16,7 @@
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
   <artifactId>zxing.appspot.com</artifactId>
-  <version>3.3.3-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <dependencies>

--- a/zxingorg/pom.xml
+++ b/zxingorg/pom.xml
@@ -16,19 +16,17 @@
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
   <artifactId>zxingorg</artifactId>
-  <version>3.3.3-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.google.zxing</groupId>
-      <artifactId>core</artifactId>
+      <artifactId>zxing-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.zxing</groupId>
-      <artifactId>javase</artifactId>
+      <artifactId>zxing-javase</artifactId>
     </dependency>
     <dependency>
       <groupId>javax</groupId>


### PR DESCRIPTION
The idea is to have a standard prefix for all _zxing_ artifacts so they don't conflict with existing ones (IMO) `core`, `javase`, `android` are too generic and might "collide" with others. Furthermore, the prefix makes it perfectly clear at a glance what is the function of the deployed JAR/WAR/artifact.

I am aware that this breaks backward compatibility in the sense that _Maven_ POM(s) using them will need to be updated, but in the long run I believe this is the correct way to go - see [Spring](https://spring.io/projects), [Hibernate](http://hibernate.org/) and others that use this convention.

P.S. I also removed the `<version>` where artifact version is same as the parent as it is the default _Maven_ behavior and also makes the POM(s) more robust since we avoid version duplication (a.k.a. the [D.R.Y. principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)). Note that I have left the special version override `4.7.7` in the _android_ POM.