### PR TITLE
Added a workaround for low framerate issue on Nexus 4

### DIFF
--- a/android/src/com/google/zxing/client/android/camera/CameraConfigurationManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraConfigurationManager.java
@@ -183,6 +183,10 @@ final class CameraConfigurationManager {
 
     parameters.setPreviewSize(bestPreviewSize.x, bestPreviewSize.y);
 
+    //SetRecordingHint to true also a workaround for low framerate on Nexus 4
+    //https://stackoverflow.com/questions/14131900/extreme-camera-lag-on-nexus-4
+    parameters.setRecordingHint(true);
+
     theCamera.setParameters(parameters);
 
     theCamera.setDisplayOrientation(cwRotationFromDisplayToCamera);

--- a/android/src/com/google/zxing/client/android/camera/CameraConfigurationManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraConfigurationManager.java
@@ -179,13 +179,13 @@ final class CameraConfigurationManager {
         CameraConfigurationUtils.setMetering(parameters);
       }
 
+      //SetRecordingHint to true also a workaround for low framerate on Nexus 4
+      //https://stackoverflow.com/questions/14131900/extreme-camera-lag-on-nexus-4
+      parameters.setRecordingHint(true);
+
     }
 
     parameters.setPreviewSize(bestPreviewSize.x, bestPreviewSize.y);
-
-    //SetRecordingHint to true also a workaround for low framerate on Nexus 4
-    //https://stackoverflow.com/questions/14131900/extreme-camera-lag-on-nexus-4
-    parameters.setRecordingHint(true);
 
     theCamera.setParameters(parameters);
 

--- a/android/src/com/google/zxing/client/android/camera/CameraManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraManager.java
@@ -21,6 +21,7 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.hardware.Camera;
 import android.os.Handler;
+import android.os.Build;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import com.google.zxing.PlanarYUVLuminanceSource;
@@ -145,6 +146,12 @@ public final class CameraManager {
   public synchronized void startPreview() {
     OpenCamera theCamera = camera;
     if (theCamera != null && !previewing) {
+      if (Build.MODEL.equals("Nexus 4") && Build.VERSION.SDK_INT >= 14) {
+        //Workaround for low framerate on Nexus 4 https://stackoverflow.com/questions/14131900/extreme-camera-lag-on-nexus-4
+        Camera.Parameters params = theCamera.getCamera().getParameters();
+        params.setRecordingHint(true);
+        theCamera.getCamera().setParameters(params);
+      }
       theCamera.getCamera().startPreview();
       previewing = true;
       autoFocusManager = new AutoFocusManager(context, theCamera.getCamera());

--- a/android/src/com/google/zxing/client/android/camera/CameraManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraManager.java
@@ -21,7 +21,6 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.hardware.Camera;
 import android.os.Handler;
-import android.os.Build;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import com.google.zxing.PlanarYUVLuminanceSource;
@@ -146,12 +145,6 @@ public final class CameraManager {
   public synchronized void startPreview() {
     OpenCamera theCamera = camera;
     if (theCamera != null && !previewing) {
-      if (Build.MODEL.equals("Nexus 4") && Build.VERSION.SDK_INT >= 14) {
-        //Workaround for low framerate on Nexus 4 https://stackoverflow.com/questions/14131900/extreme-camera-lag-on-nexus-4
-        Camera.Parameters params = theCamera.getCamera().getParameters();
-        params.setRecordingHint(true);
-        theCamera.getCamera().setParameters(params);
-      }
       theCamera.getCamera().startPreview();
       previewing = true;
       autoFocusManager = new AutoFocusManager(context, theCamera.getCamera());


### PR DESCRIPTION
Hi there,

Thanks for your great work!
I have tested ZXing on my Nexus 4 and found it suffers from a low frame rate issue. The camera is very slow and appears choppy on Nexus 4. Although it does not affect the major functionality but it still affects the usability.
I also found the following Stack Overflow discussions and adopted the workaround in this pull request.

Reference Stack Overflow Posts:
[Stack Overflow Post 1](https://stackoverflow.com/questions/20252352/image-preview-is-very-slow-on-nexus4)
[Stack Overflow Post 2](https://stackoverflow.com/questions/14131900/extreme-camera-lag-on-nexus-4)

Thanks! If you need further information, I may make a video to show the slow camera on Nexus 4.