### PR TITLE
Set protocol to JABBER if XMPP IM handle is found

### DIFF
--- a/android/src/com/google/zxing/client/android/result/ResultHandler.java
+++ b/android/src/com/google/zxing/client/android/result/ResultHandler.java
@@ -278,8 +278,14 @@ public abstract class ResultHandler {
       // Remove extra leading '\n'
       putExtra(intent, ContactsContract.Intents.Insert.NOTES, aggregatedNotes.substring(1));
     }
-    
-    putExtra(intent, ContactsContract.Intents.Insert.IM_HANDLE, instantMessenger);
+
+    if (instantMessenger != null && instantMessenger.startsWith("xmpp:")) {
+      intent.putExtra(ContactsContract.Intents.Insert.IM_PROTOCOL, ContactsContract.CommonDataKinds.Im.PROTOCOL_JABBER);
+      intent.putExtra(ContactsContract.Intents.Insert.IM_HANDLE, instantMessenger.substring(5));
+    } else {
+      putExtra(intent, ContactsContract.Intents.Insert.IM_HANDLE, instantMessenger);
+    }
+
     putExtra(intent, ContactsContract.Intents.Insert.POSTAL, address);
     if (addressType != null) {
       int type = toAddressContractType(addressType);


### PR DESCRIPTION
IMPP field can be set [to a URI][0]. If that URI is of XMPP scheme set the protocol used to JABBER and drop the scheme part from the IM handle.

This format is used by XMPP messengers e.g. [Conversations.im][1].

[0]: https://tools.ietf.org/html/rfc6350#section-6.4.3

[1]: https://github.com/siacs/Conversations/blob/master/README.md#how-does-the-address-book-integration-work