### PR TITLE
Optimize buffer size

### DIFF
--- a/core/src/main/java/com/google/zxing/common/BitArray.java
+++ b/core/src/main/java/com/google/zxing/common/BitArray.java
@@ -339,7 +339,7 @@ public final class BitArray implements Cloneable {
 
   @Override
   public String toString() {
-    StringBuilder result = new StringBuilder(size);
+    StringBuilder result = new StringBuilder(size + (size / 8) + 1);
     for (int i = 0; i < size; i++) {
       if ((i & 0x07) == 0) {
         result.append(' ');

--- a/core/src/main/java/com/google/zxing/common/BitMatrix.java
+++ b/core/src/main/java/com/google/zxing/common/BitMatrix.java
@@ -200,7 +200,7 @@ public final class BitMatrix implements Cloneable {
         || rowSize != mask.getRowSize()) {
       throw new IllegalArgumentException("input matrix dimensions do not match");
     }
-    BitArray rowArray = new BitArray(width / 32 + 1);
+    BitArray rowArray = new BitArray(width);
     for (int y = 0; y < height; y++) {
       int offset = y * rowSize;
       int[] row = mask.getRow(y, rowArray).getBitArray();


### PR DESCRIPTION
Optimize buffer size in `BitMatrix.xor()` and `BitArray.toString()`.

In BitMatrix.xor(), small buffer size causes allocation of BitArray every time in following loop.
(see BitMatrix.getRow)

BitArray change is just optimization.