### PR TITLE
Remove spacing from head of polynomial string

### DIFF
--- a/core/src/main/java/com/google/zxing/common/reedsolomon/GenericGFPoly.java
+++ b/core/src/main/java/com/google/zxing/common/reedsolomon/GenericGFPoly.java
@@ -225,15 +225,19 @@ final class GenericGFPoly {
 
   @Override
   public String toString() {
-    if (getDegree() == 0) {
-      return Integer.toString(getCoefficient(0));
+    if (isZero()) {
+      return "0";
     }
     StringBuilder result = new StringBuilder(8 * getDegree());
     for (int degree = getDegree(); degree >= 0; degree--) {
       int coefficient = getCoefficient(degree);
       if (coefficient != 0) {
         if (coefficient < 0) {
-          result.append(" - ");
+          if (degree == getDegree()) {
+            result.append("-");
+          } else {
+            result.append(" - ");
+          }
           coefficient = -coefficient;
         } else {
           if (result.length() > 0) {

--- a/core/src/test/java/com/google/zxing/common/reedsolomon/GenericGFPolyTestCase.java
+++ b/core/src/test/java/com/google/zxing/common/reedsolomon/GenericGFPolyTestCase.java
@@ -32,6 +32,8 @@ public final class GenericGFPolyTestCase extends Assert {
     assertEquals("-1", FIELD.buildMonomial(0, -1).toString());
     GenericGFPoly p = new GenericGFPoly(FIELD, new int[] {3, 0, -2, 1, 1});
     assertEquals("a^25x^4 - ax^2 + x + 1", p.toString());
+    p = new GenericGFPoly(FIELD, new int[] {3});
+    assertEquals("a^25", p.toString());
   }
 
   @Test


### PR DESCRIPTION
Does your modification intend to remove spaces around minus sign on head of polynomial?
I found a bug that string of `GenericGFPoly(QR_CODE_FIELD_256, new int[] {3})` should be `"a^25"`, not `"3"`.