### PR TITLE
Fix QR-code hanzi segment decoder

### DIFF
--- a/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
@@ -160,7 +160,7 @@ final class DecodedBitStreamParser {
       // Each 13 bits encodes a 2-byte character
       int twoBytes = bits.readBits(13);
       int assembledTwoBytes = ((twoBytes / 0x060) << 8) | (twoBytes % 0x060);
-      if (assembledTwoBytes < 0x003BF) {
+      if (assembledTwoBytes < 0x00A00) {
         // In the 0xA1A1 to 0xAAFE range
         assembledTwoBytes += 0x0A1A1;
       } else {

--- a/core/src/test/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParserTestCase.java
+++ b/core/src/test/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParserTestCase.java
@@ -81,6 +81,19 @@ public final class DecodedBitStreamParserTestCase extends Assert {
     assertEquals("\u963f", result);
   }
 
+  @Test
+  public void testHanziLevel1() throws Exception {
+    BitSourceBuilder builder = new BitSourceBuilder();
+    builder.write(0x0D, 4); // Hanzi mode
+    builder.write(0x01, 4); // Subset 1 = GB2312 encoding
+    builder.write(0x01, 8); // 1 characters
+    // A5A2 (ア, U+30A2) => A5A2 - A1A1 = 401, 4*60 + 01 = 0181
+    builder.write(0x0181, 13);
+    String result = DecodedBitStreamParser.decode(builder.toByteArray(),
+        Version.getVersionForNumber(1), null, null).getText();
+    assertEquals("\u30a2", result);
+  }
+
   // TODO definitely need more tests here
 
 }

--- a/core/src/test/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParserTestCase.java
+++ b/core/src/test/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParserTestCase.java
@@ -87,7 +87,7 @@ public final class DecodedBitStreamParserTestCase extends Assert {
     builder.write(0x0D, 4); // Hanzi mode
     builder.write(0x01, 4); // Subset 1 = GB2312 encoding
     builder.write(0x01, 8); // 1 characters
-    // A5A2 (ア, U+30A2) => A5A2 - A1A1 = 401, 4*60 + 01 = 0181
+    // A5A2 (U+30A2) => A5A2 - A1A1 = 401, 4*60 + 01 = 0181
     builder.write(0x0181, 13);
     String result = DecodedBitStreamParser.decode(builder.toByteArray(),
         Version.getVersionForNumber(1), null, null).getText();


### PR DESCRIPTION
Some hanzi characters (`A560` to `AAFE` on BG2312) could not be decoded, by wrong border value.
The new value `0xA00` means `0xB0A1 - 0xA6A1`.