### PR TITLE
Add basic support for JSR 376 modules

### DIFF
--- a/javase/pom.xml
+++ b/javase/pom.xml
@@ -16,7 +16,7 @@
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <artifactId>javase</artifactId>
   <version>3.3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -64,6 +64,17 @@
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.google.zxing.client.j2se</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
   <modules>
     <module>core</module>
     <module>javase</module>
+    <module>translator</module>
     <!-- android modules are activated by a profile below -->
     <module>zxingorg</module>
     <!-- appspot app activated by a profile below -->

--- a/translator/pom.xml
+++ b/translator/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>core</artifactId>
+  <artifactId>translator</artifactId>
   <version>3.3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
@@ -35,54 +35,15 @@
     <version>3.3.4-SNAPSHOT</version>
   </parent>
 
-  <name>ZXing Core</name>
-  <description>Core barcode encoding/decoding library</description>
-
-  <profiles>
-    <profile>
-      <id>proguard-library</id>
-      <activation>
-        <jdk>[,9)</jdk> <!-- Proguard won't work with JDK 9 -->
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.wvengen</groupId>
-            <artifactId>proguard-maven-plugin</artifactId>
-            <version>${proguard.plugin.version}</version>
-            <configuration>
-              <options combine.children="append">
-                <option>-optimizations !code/simplification/cast,!code/allocation/variable,!field/*,!class/*,!method/*</option>
-              </options>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
-      <plugin>
-        <groupId>biz.aQute.bnd</groupId>
-        <artifactId>bnd-maven-plugin</artifactId>
-        <version>3.5.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>bnd-process</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
             <manifestEntries>
-              <Automatic-Module-Name>com.google.zxing.core</Automatic-Module-Name>
+              <Automatic-Module-Name>com.google.zxing.client.translator</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>
@@ -90,5 +51,7 @@
     </plugins>
   </build>
 
-</project>
+  <name>ZXing Java SE translator</name>
+  <description>Java SE-specific translator for ZXing library</description>
 
+</project>

--- a/translator/src/main/java/com/google/zxing/client/translator/HtmlAssetTranslator.java
+++ b/translator/src/main/java/com/google/zxing/client/translator/HtmlAssetTranslator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.zxing;
+package com.google.zxing.client.translator;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -52,12 +52,12 @@ import java.util.regex.Pattern;
  * as a comma-separated list. Specify "all" for language to try to translate for all existing translations.
  * Each argument after this is the name of a file to translate; if the first one is "all", all files will
  * be translated.</p>
- * 
+ *
  * <p>Usage: {@code HtmlAssetTranslator android/assets/ (all|lang1[,lang2 ...]) (all|file1.html[ file2.html ...])}</p>
  *
- * <p>{@code android/assets/ es all} will translate .html files in subdirectory html-en to 
- * directory html-es, for example. Note that only text nodes in the HTML document are translated. 
- * Any text that is a child of a node with {@code class="notranslate"} will not be translated. It will 
+ * <p>{@code android/assets/ es all} will translate .html files in subdirectory html-en to
+ * directory html-es, for example. Note that only text nodes in the HTML document are translated.
+ * Any text that is a child of a node with {@code class="notranslate"} will not be translated. It will
  * also add a note at the end of the translated page that indicates it was automatically translated.</p>
  *
  * @author Sean Owen

--- a/translator/src/main/java/com/google/zxing/client/translator/StringsResourceTranslator.java
+++ b/translator/src/main/java/com/google/zxing/client/translator/StringsResourceTranslator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.zxing;
+package com.google.zxing.client.translator;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -53,19 +53,20 @@ import java.util.regex.Pattern;
 public final class StringsResourceTranslator {
 
   private static final String API_KEY = System.getProperty("translateAPI.key");
+
   static {
     if (API_KEY == null) {
       throw new IllegalArgumentException("translateAPI.key is not specified");
     }
   }
-  
+
   private static final Pattern ENTRY_PATTERN = Pattern.compile("<string name=\"([^\"]+)\".*>([^<]+)</string>");
   private static final Pattern STRINGS_FILE_NAME_PATTERN = Pattern.compile("values-(.+)");
   private static final Pattern TRANSLATE_RESPONSE_PATTERN = Pattern.compile("translatedText\":\\s*\"([^\"]+)\"");
   private static final Pattern VALUES_DIR_PATTERN = Pattern.compile("values-[a-z]{2}(-[a-zA-Z]{2,3})?");
 
   private static final String APACHE_2_LICENSE =
-      "<!--\n" +
+    "<!--\n" +
       " Copyright (C) 2015 ZXing authors\n" +
       '\n' +
       " Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
@@ -81,13 +82,15 @@ public final class StringsResourceTranslator {
       " limitations under the License.\n" +
       " -->\n";
 
-  private static final Map<String,String> LANGUAGE_CODE_MASSAGINGS = new HashMap<>(3);
+  private static final Map<String, String> LANGUAGE_CODE_MASSAGINGS = new HashMap<>(3);
+
   static {
     LANGUAGE_CODE_MASSAGINGS.put("zh-rCN", "zh-cn");
     LANGUAGE_CODE_MASSAGINGS.put("zh-rTW", "zh-tw");
   }
 
-  private StringsResourceTranslator() {}
+  private StringsResourceTranslator() {
+  }
 
   public static void main(String[] args) throws IOException {
     Path resDir = Paths.get(args[0]);
@@ -99,7 +102,7 @@ public final class StringsResourceTranslator {
       @Override
       public boolean accept(Path entry) {
         return Files.isDirectory(entry) && !Files.isSymbolicLink(entry) &&
-            VALUES_DIR_PATTERN.matcher(entry.getFileName().toString()).matches();
+          VALUES_DIR_PATTERN.matcher(entry.getFileName().toString()).matches();
       }
     };
     try (DirectoryStream<Path> dirs = Files.newDirectoryStream(resDir, filter)) {
@@ -114,7 +117,7 @@ public final class StringsResourceTranslator {
                                 Collection<String> forceRetranslation) throws IOException {
 
     Map<String, String> english = readLines(englishFile);
-    Map<String,String> translated = readLines(translatedFile);
+    Map<String, String> translated = readLines(translatedFile);
     String parentName = translatedFile.getParent().getFileName().toString();
 
     Matcher stringsFileNameMatcher = STRINGS_FILE_NAME_PATTERN.matcher(parentName);
@@ -137,7 +140,7 @@ public final class StringsResourceTranslator {
       out.write(APACHE_2_LICENSE);
       out.write("<resources>\n");
 
-      for (Map.Entry<String,String> englishEntry : english.entrySet()) {
+      for (Map.Entry<String, String> englishEntry : english.entrySet()) {
         String key = englishEntry.getKey();
         String value = englishEntry.getValue();
         out.write("  <string name=\"");
@@ -184,9 +187,9 @@ public final class StringsResourceTranslator {
     System.out.println("  Need translation for " + english);
 
     URI translateURI = URI.create(
-        "https://www.googleapis.com/language/translate/v2?key=" + API_KEY + "&q=" +
-            URLEncoder.encode(english, "UTF-8") +
-            "&source=en&target=" + language);
+      "https://www.googleapis.com/language/translate/v2?key=" + API_KEY + "&q=" +
+        URLEncoder.encode(english, "UTF-8") +
+        "&source=en&target=" + language);
     CharSequence translateResult = fetch(translateURI);
     Matcher m = TRANSLATE_RESPONSE_PATTERN.matcher(translateResult);
     if (!m.find()) {
@@ -218,9 +221,9 @@ public final class StringsResourceTranslator {
     return translateResult;
   }
 
-  private static Map<String,String> readLines(Path file) throws IOException {
+  private static Map<String, String> readLines(Path file) throws IOException {
     if (Files.exists(file)) {
-      Map<String,String> entries = new TreeMap<>();
+      Map<String, String> entries = new TreeMap<>();
       for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
         Matcher m = ENTRY_PATTERN.matcher(line);
         if (m.find()) {


### PR DESCRIPTION
Add Automatic-Module-Name to core and javase
Move Translator files to their own module as a single package can only be contained within one module.