### PR TITLE
Check if characters are digits for EAN_13, EAN_8, ITF and UPC_EAN_EXTENSION

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/EAN13Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN13Writer.java
@@ -80,6 +80,11 @@ public final class EAN13Writer extends UPCEANWriter {
 
 
     int firstDigit = Character.digit(contents.charAt(0), 10);
+    
+    if (firstDigit == -1) {
+      throw new IllegalArgumentException("Input should only contain digits 0-9");
+    }
+
     int parities = EAN13Reader.FIRST_DIGIT_ENCODINGS[firstDigit];
     boolean[] result = new boolean[CODE_WIDTH];
     int pos = 0;
@@ -89,6 +94,11 @@ public final class EAN13Writer extends UPCEANWriter {
     // See EAN13Reader for a description of how the first digit & left bars are encoded
     for (int i = 1; i <= 6; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
+
+      if (digit == -1) {
+        throw new IllegalArgumentException("Input should only contain digits 0-9");
+      }
+
       if ((parities >> (6 - i) & 1) == 1) {
         digit += 10;
       }
@@ -99,6 +109,11 @@ public final class EAN13Writer extends UPCEANWriter {
 
     for (int i = 7; i <= 12; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
+
+      if (digit == -1) {
+        throw new IllegalArgumentException("Input should only contain digits 0-9");
+      }
+
       pos += appendPattern(result, pos, UPCEANReader.L_PATTERNS[digit], true);
     }
     appendPattern(result, pos, UPCEANReader.START_END_PATTERN, true);

--- a/core/src/main/java/com/google/zxing/oned/EAN13Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN13Writer.java
@@ -78,9 +78,7 @@ public final class EAN13Writer extends UPCEANWriter {
             "Requested contents should be 12 or 13 digits long, but got " + length);
     }
 
-    if (!checkNumeric(contents)) {
-      throw new IllegalArgumentException("Input should only contain digits 0-9.");
-    }
+    checkNumeric(contents);
 
     int firstDigit = Character.digit(contents.charAt(0), 10);
     int parities = EAN13Reader.FIRST_DIGIT_ENCODINGS[firstDigit];

--- a/core/src/main/java/com/google/zxing/oned/EAN13Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN13Writer.java
@@ -78,13 +78,11 @@ public final class EAN13Writer extends UPCEANWriter {
             "Requested contents should be 12 or 13 digits long, but got " + length);
     }
 
-
-    int firstDigit = Character.digit(contents.charAt(0), 10);
-    
-    if (firstDigit == -1) {
-      throw new IllegalArgumentException("Input should only contain digits 0-9");
+    if (!NUMERIC.matcher(contents).matches()) {
+      throw new IllegalArgumentException("Input should only contain digits 0-9.");
     }
 
+    int firstDigit = Character.digit(contents.charAt(0), 10);
     int parities = EAN13Reader.FIRST_DIGIT_ENCODINGS[firstDigit];
     boolean[] result = new boolean[CODE_WIDTH];
     int pos = 0;
@@ -94,11 +92,6 @@ public final class EAN13Writer extends UPCEANWriter {
     // See EAN13Reader for a description of how the first digit & left bars are encoded
     for (int i = 1; i <= 6; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
-
-      if (digit == -1) {
-        throw new IllegalArgumentException("Input should only contain digits 0-9");
-      }
-
       if ((parities >> (6 - i) & 1) == 1) {
         digit += 10;
       }
@@ -109,11 +102,6 @@ public final class EAN13Writer extends UPCEANWriter {
 
     for (int i = 7; i <= 12; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
-
-      if (digit == -1) {
-        throw new IllegalArgumentException("Input should only contain digits 0-9");
-      }
-
       pos += appendPattern(result, pos, UPCEANReader.L_PATTERNS[digit], true);
     }
     appendPattern(result, pos, UPCEANReader.START_END_PATTERN, true);

--- a/core/src/main/java/com/google/zxing/oned/EAN13Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN13Writer.java
@@ -78,7 +78,7 @@ public final class EAN13Writer extends UPCEANWriter {
             "Requested contents should be 12 or 13 digits long, but got " + length);
     }
 
-    if (!NUMERIC.matcher(contents).matches()) {
+    if (!checkNumeric(contents)) {
       throw new IllegalArgumentException("Input should only contain digits 0-9.");
     }
 

--- a/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
@@ -82,7 +82,7 @@ public final class EAN8Writer extends UPCEANWriter {
             "Requested contents should be 8 digits long, but got " + length);
     }
 
-    if (!NUMERIC.matcher(contents).matches()) {
+    if (!checkNumeric(contents)) {
       throw new IllegalArgumentException("Input should only contain digits 0-9.");
     }
 

--- a/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
@@ -89,6 +89,11 @@ public final class EAN8Writer extends UPCEANWriter {
 
     for (int i = 0; i <= 3; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
+
+      if (digit == -1) {
+        throw new IllegalArgumentException("Input should only contain digits 0-9");
+      }
+
       pos += appendPattern(result, pos, UPCEANReader.L_PATTERNS[digit], false);
     }
 
@@ -96,6 +101,11 @@ public final class EAN8Writer extends UPCEANWriter {
 
     for (int i = 4; i <= 7; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
+      
+      if (digit == -1) {
+        throw new IllegalArgumentException("Input should only contain digits 0-9");
+      }
+
       pos += appendPattern(result, pos, UPCEANReader.L_PATTERNS[digit], true);
     }
     appendPattern(result, pos, UPCEANReader.START_END_PATTERN, true);

--- a/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
@@ -82,9 +82,7 @@ public final class EAN8Writer extends UPCEANWriter {
             "Requested contents should be 8 digits long, but got " + length);
     }
 
-    if (!checkNumeric(contents)) {
-      throw new IllegalArgumentException("Input should only contain digits 0-9.");
-    }
+    checkNumeric(contents);
 
     boolean[] result = new boolean[CODE_WIDTH];
     int pos = 0;

--- a/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
@@ -82,6 +82,10 @@ public final class EAN8Writer extends UPCEANWriter {
             "Requested contents should be 8 digits long, but got " + length);
     }
 
+    if (!NUMERIC.matcher(contents).matches()) {
+      throw new IllegalArgumentException("Input should only contain digits 0-9.");
+    }
+
     boolean[] result = new boolean[CODE_WIDTH];
     int pos = 0;
 
@@ -89,11 +93,6 @@ public final class EAN8Writer extends UPCEANWriter {
 
     for (int i = 0; i <= 3; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
-
-      if (digit == -1) {
-        throw new IllegalArgumentException("Input should only contain digits 0-9");
-      }
-
       pos += appendPattern(result, pos, UPCEANReader.L_PATTERNS[digit], false);
     }
 
@@ -101,11 +100,6 @@ public final class EAN8Writer extends UPCEANWriter {
 
     for (int i = 4; i <= 7; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
-      
-      if (digit == -1) {
-        throw new IllegalArgumentException("Input should only contain digits 0-9");
-      }
-
       pos += appendPattern(result, pos, UPCEANReader.L_PATTERNS[digit], true);
     }
     appendPattern(result, pos, UPCEANReader.START_END_PATTERN, true);

--- a/core/src/main/java/com/google/zxing/oned/ITFWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/ITFWriter.java
@@ -75,7 +75,9 @@ public final class ITFWriter extends OneDimensionalCodeWriter {
           "Requested contents should be less than 80 digits long, but got " + length);
     }
 
-    if (!NUMERIC.matcher(contents).matches()) {
+    
+
+    if (!checkNumeric(contents)) {
       throw new IllegalArgumentException("Input should only contain digits 0-9.");
     }
 

--- a/core/src/main/java/com/google/zxing/oned/ITFWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/ITFWriter.java
@@ -79,7 +79,13 @@ public final class ITFWriter extends OneDimensionalCodeWriter {
     for (int i = 0; i < length; i += 2) {
       int one = Character.digit(contents.charAt(i), 10);
       int two = Character.digit(contents.charAt(i + 1), 10);
+      
+      if (one == -1 || two == -1) {
+        throw new IllegalArgumentException("Input contains invalid characters");
+      }
+
       int[] encoding = new int[10];
+
       for (int j = 0; j < 5; j++) {
         encoding[2 * j] = PATTERNS[one][j];
         encoding[2 * j + 1] = PATTERNS[two][j];

--- a/core/src/main/java/com/google/zxing/oned/ITFWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/ITFWriter.java
@@ -75,11 +75,7 @@ public final class ITFWriter extends OneDimensionalCodeWriter {
           "Requested contents should be less than 80 digits long, but got " + length);
     }
 
-    
-
-    if (!checkNumeric(contents)) {
-      throw new IllegalArgumentException("Input should only contain digits 0-9.");
-    }
+    checkNumeric(contents);
 
     boolean[] result = new boolean[9 + 9 * length];
     int pos = appendPattern(result, 0, START_PATTERN, true);

--- a/core/src/main/java/com/google/zxing/oned/ITFWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/ITFWriter.java
@@ -74,18 +74,17 @@ public final class ITFWriter extends OneDimensionalCodeWriter {
       throw new IllegalArgumentException(
           "Requested contents should be less than 80 digits long, but got " + length);
     }
+
+    if (!NUMERIC.matcher(contents).matches()) {
+      throw new IllegalArgumentException("Input should only contain digits 0-9.");
+    }
+
     boolean[] result = new boolean[9 + 9 * length];
     int pos = appendPattern(result, 0, START_PATTERN, true);
     for (int i = 0; i < length; i += 2) {
       int one = Character.digit(contents.charAt(i), 10);
       int two = Character.digit(contents.charAt(i + 1), 10);
-      
-      if (one == -1 || two == -1) {
-        throw new IllegalArgumentException("Input contains invalid characters");
-      }
-
       int[] encoding = new int[10];
-
       for (int j = 0; j < 5; j++) {
         encoding[2 * j] = PATTERNS[one][j];
         encoding[2 * j + 1] = PATTERNS[two][j];

--- a/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
@@ -23,6 +23,7 @@ import com.google.zxing.WriterException;
 import com.google.zxing.common.BitMatrix;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * <p>Encapsulates functionality and implementation that is common to one-dimensional barcodes.</p>
@@ -90,6 +91,7 @@ public abstract class OneDimensionalCodeWriter implements Writer {
     return output;
   }
 
+  private static final Pattern NUMERIC = Pattern.compile("[0-9]+");
 
   /**
    * @param target encode black/white pattern into this array

--- a/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
@@ -93,6 +93,10 @@ public abstract class OneDimensionalCodeWriter implements Writer {
 
   private static final Pattern NUMERIC = Pattern.compile("[0-9]+");
 
+  protected static boolean checkNumeric(String contents) {
+    return NUMERIC.matcher(contents).matches();
+  }
+
   /**
    * @param target encode black/white pattern into this array
    * @param pos position to start encoding at in {@code target}

--- a/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
@@ -95,9 +95,9 @@ public abstract class OneDimensionalCodeWriter implements Writer {
   /**
    * Throw IllegalArgumentException if input contains characters other than digits 0-9.
    */
-  protected static final void checkNumeric(String contents) throws IllegalArgumentException{
+  protected static final void checkNumeric(String contents) throws IllegalArgumentException {
     if (!NUMERIC.matcher(contents).matches()) {
-        throw new IllegalArgumentException("Input should only contain digits 0-9");
+      throw new IllegalArgumentException("Input should only contain digits 0-9");
     }
   }
 

--- a/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
  * @author dsbnatut@gmail.com (Kazuki Nishiura)
  */
 public abstract class OneDimensionalCodeWriter implements Writer {
+  private static final Pattern NUMERIC = Pattern.compile("[0-9]+");
 
   @Override
   public final BitMatrix encode(String contents, BarcodeFormat format, int width, int height)
@@ -90,8 +91,6 @@ public abstract class OneDimensionalCodeWriter implements Writer {
     }
     return output;
   }
-
-  private static final Pattern NUMERIC = Pattern.compile("[0-9]+");
 
   protected static boolean checkNumeric(String contents) {
     return NUMERIC.matcher(contents).matches();

--- a/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
@@ -92,8 +92,13 @@ public abstract class OneDimensionalCodeWriter implements Writer {
     return output;
   }
 
-  protected static boolean checkNumeric(String contents) {
-    return NUMERIC.matcher(contents).matches();
+  /**
+   * Throw IllegalArgumentException if input contains characters other than digits 0-9.
+   */
+  protected static final void checkNumeric(String contents) throws IllegalArgumentException{
+    if (!NUMERIC.matcher(contents).matches()) {
+        throw new IllegalArgumentException("Input should only contain digits 0-9");
+    }
   }
 
   /**

--- a/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
@@ -76,17 +76,16 @@ public final class UPCEWriter extends UPCEANWriter {
             "Requested contents should be 8 digits long, but got " + length);
     }
 
+    if (!NUMERIC.matcher(contents).matches()) {
+      throw new IllegalArgumentException("Input should only contain digits 0-9.");
+    }
+
     int firstDigit = Character.digit(contents.charAt(0), 10);
     if (firstDigit != 0 && firstDigit != 1) {
       throw new IllegalArgumentException("Number system must be 0 or 1");
     }
 
     int checkDigit = Character.digit(contents.charAt(7), 10);
-
-    if (checkDigit == -1) {
-      throw new IllegalArgumentException("Input should only contain digits 0-9");
-    }
-
     int parities = UPCEReader.NUMSYS_AND_CHECK_DIGIT_PATTERNS[firstDigit][checkDigit];
     boolean[] result = new boolean[CODE_WIDTH];
     int pos = 0;
@@ -95,10 +94,6 @@ public final class UPCEWriter extends UPCEANWriter {
 
     for (int i = 1; i <= 6; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
-      if (digit == -1) {
-        throw new IllegalArgumentException("Input should only contain digits 0-9");
-      }
-
       if ((parities >> (6 - i) & 1) == 1) {
         digit += 10;
       }

--- a/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
@@ -82,6 +82,11 @@ public final class UPCEWriter extends UPCEANWriter {
     }
 
     int checkDigit = Character.digit(contents.charAt(7), 10);
+
+    if (checkDigit == -1) {
+      throw new IllegalArgumentException("Input should only contain digits 0-9");
+    }
+
     int parities = UPCEReader.NUMSYS_AND_CHECK_DIGIT_PATTERNS[firstDigit][checkDigit];
     boolean[] result = new boolean[CODE_WIDTH];
     int pos = 0;
@@ -90,6 +95,10 @@ public final class UPCEWriter extends UPCEANWriter {
 
     for (int i = 1; i <= 6; i++) {
       int digit = Character.digit(contents.charAt(i), 10);
+      if (digit == -1) {
+        throw new IllegalArgumentException("Input should only contain digits 0-9");
+      }
+
       if ((parities >> (6 - i) & 1) == 1) {
         digit += 10;
       }

--- a/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
@@ -76,9 +76,7 @@ public final class UPCEWriter extends UPCEANWriter {
             "Requested contents should be 8 digits long, but got " + length);
     }
 
-    if (!checkNumeric(contents)) {
-      throw new IllegalArgumentException("Input should only contain digits 0-9.");
-    }
+    checkNumeric(contents);
 
     int firstDigit = Character.digit(contents.charAt(0), 10);
     if (firstDigit != 0 && firstDigit != 1) {

--- a/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/UPCEWriter.java
@@ -76,7 +76,7 @@ public final class UPCEWriter extends UPCEANWriter {
             "Requested contents should be 8 digits long, but got " + length);
     }
 
-    if (!NUMERIC.matcher(contents).matches()) {
+    if (!checkNumeric(contents)) {
       throw new IllegalArgumentException("Input should only contain digits 0-9.");
     }
 

--- a/core/src/test/java/com/google/zxing/oned/EAN13WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/EAN13WriterTestCase.java
@@ -42,4 +42,14 @@ public final class EAN13WriterTestCase extends Assert {
     assertEquals(testStr, BitMatrixTestCase.matrixToString(result));
   }
 
+  @Test
+  public void testEncodeIllegalCharacters() throws WriterException {
+    int illegalArgument = 0;
+    try {
+      BitMatrix result = new EAN13Writer().encode("5901234123abc", BarcodeFormat.EAN_13, 0, 0);
+    } catch (IllegalArgumentException e) {
+      illegalArgument = 1;
+    }
+    assertEquals(illegalArgument, 1);
+  }
 }

--- a/core/src/test/java/com/google/zxing/oned/EAN13WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/EAN13WriterTestCase.java
@@ -44,12 +44,12 @@ public final class EAN13WriterTestCase extends Assert {
 
   @Test
   public void testEncodeIllegalCharacters() throws WriterException {
-    int illegalArgument = 0;
+    boolean illegalArgument = false;
     try {
-      BitMatrix result = new EAN13Writer().encode("5901234123abc", BarcodeFormat.EAN_13, 0, 0);
+      new EAN13Writer().encode("5901234123abc", BarcodeFormat.EAN_13, 0, 0);
     } catch (IllegalArgumentException e) {
-      illegalArgument = 1;
+      illegalArgument = true;
     }
-    assertEquals(illegalArgument, 1);
+    assertEquals(illegalArgument, true);
   }
 }

--- a/core/src/test/java/com/google/zxing/oned/EAN13WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/EAN13WriterTestCase.java
@@ -42,14 +42,8 @@ public final class EAN13WriterTestCase extends Assert {
     assertEquals(testStr, BitMatrixTestCase.matrixToString(result));
   }
 
-  @Test
+  @Test(expected = IllegalArgumentException.class)
   public void testEncodeIllegalCharacters() throws WriterException {
-    boolean illegalArgument = false;
-    try {
-      new EAN13Writer().encode("5901234123abc", BarcodeFormat.EAN_13, 0, 0);
-    } catch (IllegalArgumentException e) {
-      illegalArgument = true;
-    }
-    assertEquals(illegalArgument, true);
+    new EAN13Writer().encode("5901234123abc", BarcodeFormat.EAN_13, 0, 0);
   }
 }

--- a/core/src/test/java/com/google/zxing/oned/EAN8WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/EAN8WriterTestCase.java
@@ -44,12 +44,12 @@ public final class EAN8WriterTestCase extends Assert {
 
   @Test
   public void testEncodeIllegalCharacters() throws WriterException {
-    int illegalArgument = 0;
+    boolean illegalArgument = false;
     try {
-      BitMatrix result = new EAN8Writer().encode("96385abc", BarcodeFormat.EAN_8, 0, 0);
+      new EAN8Writer().encode("96385abc", BarcodeFormat.EAN_8, 0, 0);
     } catch (IllegalArgumentException e) {
-      illegalArgument = 1;
+      illegalArgument = true;
     }
-    assertEquals(illegalArgument, 1);
+    assertEquals(illegalArgument, true);
   }
 }

--- a/core/src/test/java/com/google/zxing/oned/EAN8WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/EAN8WriterTestCase.java
@@ -42,4 +42,14 @@ public final class EAN8WriterTestCase extends Assert {
     assertEquals(testStr, BitMatrixTestCase.matrixToString(result));
   }
 
+  @Test
+  public void testEncodeIllegalCharacters() throws WriterException {
+    int illegalArgument = 0;
+    try {
+      BitMatrix result = new EAN8Writer().encode("96385abc", BarcodeFormat.EAN_8, 0, 0);
+    } catch (IllegalArgumentException e) {
+      illegalArgument = 1;
+    }
+    assertEquals(illegalArgument, 1);
+  }
 }

--- a/core/src/test/java/com/google/zxing/oned/EAN8WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/EAN8WriterTestCase.java
@@ -42,14 +42,8 @@ public final class EAN8WriterTestCase extends Assert {
     assertEquals(testStr, BitMatrixTestCase.matrixToString(result));
   }
 
-  @Test
+  @Test(expected = IllegalArgumentException.class)
   public void testEncodeIllegalCharacters() throws WriterException {
-    boolean illegalArgument = false;
-    try {
-      new EAN8Writer().encode("96385abc", BarcodeFormat.EAN_8, 0, 0);
-    } catch (IllegalArgumentException e) {
-      illegalArgument = true;
-    }
-    assertEquals(illegalArgument, true);
+    new EAN8Writer().encode("96385abc", BarcodeFormat.EAN_8, 0, 0);
   }
 }

--- a/core/src/test/java/com/google/zxing/oned/ITFWriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/ITFWriterTestCase.java
@@ -40,4 +40,15 @@ public final class ITFWriterTestCase extends Assert {
     assertEquals(expected, BitMatrixTestCase.matrixToString(result));
   }
 
+  @Test
+  public void testEncodeIllegalCharacters() throws WriterException {
+    int illegalArgument = 0;
+    try {
+      BitMatrix result = new ITFWriter().encode("00123456789abc", BarcodeFormat.ITF, 0, 0);
+    } catch (IllegalArgumentException e) {
+      illegalArgument = 1;
+    }
+    assertEquals(illegalArgument, 1);
+  }
+
 }

--- a/core/src/test/java/com/google/zxing/oned/ITFWriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/ITFWriterTestCase.java
@@ -40,16 +40,9 @@ public final class ITFWriterTestCase extends Assert {
     assertEquals(expected, BitMatrixTestCase.matrixToString(result));
   }
 
-  @Test
+  @Test(expected = IllegalArgumentException.class)
   public void testEncodeIllegalCharacters() throws WriterException {
-    boolean illegalArgument = false;
-    try {
-      new ITFWriter().encode("00123456789abc", BarcodeFormat.ITF, 0, 0);
-    } catch (IllegalArgumentException e) {
-      illegalArgument = true;
-    }
-
-    assertEquals(illegalArgument, true);
+    new ITFWriter().encode("00123456789abc", BarcodeFormat.ITF, 0, 0);
   }
 
 }

--- a/core/src/test/java/com/google/zxing/oned/ITFWriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/ITFWriterTestCase.java
@@ -42,13 +42,14 @@ public final class ITFWriterTestCase extends Assert {
 
   @Test
   public void testEncodeIllegalCharacters() throws WriterException {
-    int illegalArgument = 0;
+    boolean illegalArgument = false;
     try {
-      BitMatrix result = new ITFWriter().encode("00123456789abc", BarcodeFormat.ITF, 0, 0);
+      new ITFWriter().encode("00123456789abc", BarcodeFormat.ITF, 0, 0);
     } catch (IllegalArgumentException e) {
-      illegalArgument = 1;
+      illegalArgument = true;
     }
-    assertEquals(illegalArgument, 1);
+
+    assertEquals(illegalArgument, true);
   }
 
 }

--- a/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
@@ -55,7 +55,7 @@ public final class UPCEWriterTestCase extends Assert {
   public void testEncodeIllegalCharacters() throws WriterException {
     int illegalArgument = 0;
     try {
-      BitMatrix result = new UPCEWriter().encode("05096abc", BarcodeFormat.UPC_E, encoding.length(), 0);
+      BitMatrix result = new UPCEWriter().encode("05096abc", BarcodeFormat.UPC_E, 0, 0);
     } catch (IllegalArgumentException e) {
       illegalArgument = 1;
     }

--- a/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
@@ -51,4 +51,15 @@ public final class UPCEWriterTestCase extends Assert {
     assertEquals(encoding, BitMatrixTestCase.matrixToString(result));
   }
 
+  @Test
+  public void testEncodeIllegalCharacters() throws WriterException {
+    int illegalArgument = 0;
+    try {
+      BitMatrix result = new UPCEWriter().encode("05096abc", BarcodeFormat.UPC_E, encoding.length(), 0);
+    } catch (IllegalArgumentException e) {
+      illegalArgument = 1;
+    }
+    assertEquals(illegalArgument, 1);
+  }
+
 }

--- a/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
@@ -51,15 +51,8 @@ public final class UPCEWriterTestCase extends Assert {
     assertEquals(encoding, BitMatrixTestCase.matrixToString(result));
   }
 
-  @Test
+  @Test(expected = IllegalArgumentException.class)
   public void testEncodeIllegalCharacters() throws WriterException {
-    boolean illegalArgument = false;
-    try {
       new UPCEWriter().encode("05096abc", BarcodeFormat.UPC_E, 0, 0);
-    } catch (IllegalArgumentException e) {
-      illegalArgument = true;
-    }
-    assertEquals(illegalArgument, true);
   }
-
 }

--- a/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
@@ -53,13 +53,13 @@ public final class UPCEWriterTestCase extends Assert {
 
   @Test
   public void testEncodeIllegalCharacters() throws WriterException {
-    int illegalArgument = 0;
+    boolean illegalArgument = false;
     try {
-      BitMatrix result = new UPCEWriter().encode("05096abc", BarcodeFormat.UPC_E, 0, 0);
+      new UPCEWriter().encode("05096abc", BarcodeFormat.UPC_E, 0, 0);
     } catch (IllegalArgumentException e) {
-      illegalArgument = 1;
+      illegalArgument = true;
     }
-    assertEquals(illegalArgument, 1);
+    assertEquals(illegalArgument, true);
   }
 
 }

--- a/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/UPCEWriterTestCase.java
@@ -53,6 +53,6 @@ public final class UPCEWriterTestCase extends Assert {
 
   @Test(expected = IllegalArgumentException.class)
   public void testEncodeIllegalCharacters() throws WriterException {
-      new UPCEWriter().encode("05096abc", BarcodeFormat.UPC_E, 0, 0);
+    new UPCEWriter().encode("05096abc", BarcodeFormat.UPC_E, 0, 0);
   }
 }


### PR DESCRIPTION
Several barcode formats only support digits 0-9, namely

- BarcodeFormat.EAN_13 
- BarcodeFormat.EAN_8 
- BarcodeFormat.ITF 
- BarcodeFormat.UPC_EAN_EXTENSION

Passing different characters to the encode function causes a runtime exception. 

**Proposed solution**
Check return value of Character.digit and throw IllegalArgumentException if it is -1 (invalid character.)
Source: https://developer.android.com/reference/java/lang/Character#digit(int,%20int)
