### PR TITLE
fix binary shift cost heuristics

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/encoder/State.java
+++ b/core/src/main/java/com/google/zxing/aztec/encoder/State.java
@@ -170,15 +170,16 @@ final class State {
   }
   
   private static int calculateBinaryShiftCost(State state) {
-      if (state.binaryShiftByteCount > 62) {
-          return 21; // B/S with extended length
-      } else if (state.binaryShiftByteCount > 31) {
-          return 20; // two B/S
-      } else if (state.binaryShiftByteCount > 0) {
-          return 10; // one B/S
-      } else {
-          return 0;
-      }
+    if (state.binaryShiftByteCount > 62) {
+      return 21; // B/S with extended length
+    }
+    if (state.binaryShiftByteCount > 31) {
+      return 20; // two B/S
+    }
+    if (state.binaryShiftByteCount > 0) {
+      return 10; // one B/S
+    }
+    return 0;
   }
 
 }

--- a/core/src/main/java/com/google/zxing/aztec/encoder/State.java
+++ b/core/src/main/java/com/google/zxing/aztec/encoder/State.java
@@ -137,12 +137,15 @@ final class State {
   // Returns true if "this" state is better (or equal) to be in than "that"
   // state under all possible circumstances.
   boolean isBetterThanOrEqualTo(State other) {
-    int mySize = this.bitCount + (HighLevelEncoder.LATCH_TABLE[this.mode][other.mode] >> 16);
-    if (other.binaryShiftByteCount > 0 &&
-        (this.binaryShiftByteCount == 0 || this.binaryShiftByteCount > other.binaryShiftByteCount)) {
-      mySize += 10;     // Cost of entering Binary Shift mode.
+    int newModeBitCount = this.bitCount + (HighLevelEncoder.LATCH_TABLE[this.mode][other.mode] >> 16);
+    if (this.binaryShiftByteCount < other.binaryShiftByteCount) {
+      // add additional B/S encoding cost of other, if any
+      newModeBitCount += calculateBinaryShiftCost(other) - calculateBinaryShiftCost(this);
+    } else if (this.binaryShiftByteCount > other.binaryShiftByteCount && other.binaryShiftByteCount > 0) {
+      // maximum possible additional cost (we end up exceeding the 31 byte boundary and other state can stay beneath it)
+      newModeBitCount += 10; 
     }
-    return mySize <= other.bitCount;
+    return newModeBitCount <= other.bitCount;
   }
 
   BitArray toBitArray(byte[] text) {
@@ -164,6 +167,18 @@ final class State {
   @Override
   public String toString() {
     return String.format("%s bits=%d bytes=%d", HighLevelEncoder.MODE_NAMES[mode], bitCount, binaryShiftByteCount);
+  }
+  
+  private static int calculateBinaryShiftCost(State state) {
+      if (state.binaryShiftByteCount > 62) {
+          return 21; // B/S with extended length
+      } else if (state.binaryShiftByteCount > 31) {
+          return 20; // two B/S
+      } else if (state.binaryShiftByteCount > 0) {
+          return 10; // one B/S
+      } else {
+          return 0;
+      }
   }
 
 }

--- a/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
@@ -361,7 +361,7 @@ public final class EncoderTest extends Assert {
       // A lower case letter at both ends will enough to latch us into LOWER.
       testHighLevelEncodeString('a' + sb.substring(0, i) + 'b', expectedLength + 15);
     }
-      
+
     sb = new StringBuilder();
     for (int i = 0; i < 32; i++) {
       sb.append('§'); // § forces binary encoding
@@ -377,7 +377,7 @@ public final class EncoderTest extends Assert {
     sb.setCharAt(1, 'A');
     // expect B/S(31)
     testHighLevelEncodeString(sb.toString(), 10 + 31 * 8);
-      
+
     sb = new StringBuilder();
     for (int i = 0; i < 34; i++) {
       sb.append('§');
@@ -385,7 +385,7 @@ public final class EncoderTest extends Assert {
     sb.setCharAt(1, 'A');
     // expect B/S(31) B/S(3)
     testHighLevelEncodeString(sb.toString(), 20 + 34 * 8);
-      
+
     sb = new StringBuilder();
     for (int i = 0; i < 64; i++) {
       sb.append('§');
@@ -394,7 +394,7 @@ public final class EncoderTest extends Assert {
     // expect B/S(64)
     testHighLevelEncodeString(sb.toString(), 21 + 64 * 8);
   }
-  
+
   @Test
   public void testHighLevelEncodePairs() {
     // Typical usage

--- a/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
@@ -307,7 +307,7 @@ public final class EncoderTest extends Assert {
             + "Ygh6utAIgLl1aBVM4EOTQtMQQYH9M2Z3Dp4qnA/fwWuQ+M8L3V8U=",
         823);
   }
-
+  
   @Test
   public void testHighLevelEncodeBinary() {
     // binary short form single byte
@@ -361,6 +361,38 @@ public final class EncoderTest extends Assert {
       // A lower case letter at both ends will enough to latch us into LOWER.
       testHighLevelEncodeString('a' + sb.substring(0, i) + 'b', expectedLength + 15);
     }
+      
+    sb = new StringBuilder();
+    for (int i = 0; i < 32; i++) {
+      sb.append('§'); // § forces binary encoding
+    }
+    sb.setCharAt(1, 'A');
+    // expect B/S(1) A B/S(30)
+    testHighLevelEncodeString(sb.toString(), 5 + 20 + 31 * 8);
+
+    sb = new StringBuilder();
+    for (int i = 0; i < 31; i++) {
+      sb.append('§');
+    }
+    sb.setCharAt(1, 'A');
+    // expect B/S(31)
+    testHighLevelEncodeString(sb.toString(), 10 + 31 * 8);
+      
+    sb = new StringBuilder();
+    for (int i = 0; i < 34; i++) {
+      sb.append('§');
+    }
+    sb.setCharAt(1, 'A');
+    // expect B/S(31) B/S(3)
+    testHighLevelEncodeString(sb.toString(), 20 + 34 * 8);
+      
+    sb = new StringBuilder();
+    for (int i = 0; i < 64; i++) {
+      sb.append('§');
+    }
+    sb.setCharAt(30, 'A');
+    // expect B/S(64)
+    testHighLevelEncodeString(sb.toString(), 21 + 64 * 8);
   }
   
   @Test


### PR DESCRIPTION
This introduces some tests that show that the current heuristic that determines whether an encoding state can savely been dropped isn't valid for binary shift mode. That flaw may lead to inefficent encoding for non-textual data, i.e. the encoding uses some more bytes than the original octet encoding does.

It also comes with the fix for that heuristic.