### PR TITLE
Directory Bug

### DIFF
--- a/android/src/com/google/zxing/client/android/history/HistoryManager.java
+++ b/android/src/com/google/zxing/client/android/history/HistoryManager.java
@@ -298,7 +298,7 @@ public final class HistoryManager {
   static Uri saveHistory(String history) {
     File bsRoot = new File(Environment.getExternalStorageDirectory(), "BarcodeScanner");
     File historyRoot = new File(bsRoot, "History");
-    if (!historyRoot.exists() && !historyRoot.mkdirs()) {
+    if (!historyRoot.mkdirs() && !historyRoot.isDirectory()) {
       Log.w(TAG, "Couldn't make dir " + historyRoot);
       return null;
     }


### PR DESCRIPTION
The correct pattern to make a directory is: `if (!dir.mkdirs() && !dir.isDirectory()) { error }` mkdirs checks for exists so the exists check is redundant.