### PR TITLE
Directory Bug

### DIFF
--- a/android/src/com/google/zxing/client/android/encode/EncodeActivity.java
+++ b/android/src/com/google/zxing/client/android/encode/EncodeActivity.java
@@ -139,7 +139,7 @@ public final class EncodeActivity extends Activity {
 
     File bsRoot = new File(Environment.getExternalStorageDirectory(), "BarcodeScanner");
     File barcodesRoot = new File(bsRoot, "Barcodes");
-    if (!barcodesRoot.exists() && !barcodesRoot.mkdirs()) {
+    if (!barcodesRoot.mkdirs() && !barcodesRoot.isDirectory()) {
       Log.w(TAG, "Couldn't make dir " + barcodesRoot);
       showErrorMessage(R.string.msg_unmount_usb);
       return;


### PR DESCRIPTION
The correct pattern to make a directory is: `if (!dir.mkdirs() && !dir.isDirectory()) { error }` mkdirs checks for exists so the exists check is redundant.