### PR TITLE
Fixed duplicated assertion

### DIFF
--- a/core/src/test/java/com/google/zxing/common/BitArrayTestCase.java
+++ b/core/src/test/java/com/google/zxing/common/BitArrayTestCase.java
@@ -225,7 +225,7 @@ public final class BitArrayTestCase extends Assert {
     assertEquals(a.hashCode(), b.hashCode());
     assertNotEquals(a, new BitArray(31));
     a.set(16);
-    assertNotEquals(a, new BitArray(31));
+    assertNotEquals(a, b);
     assertNotEquals(a.hashCode(), b.hashCode());
     b.set(16);
     assertEquals(a, b);


### PR DESCRIPTION
I am currently porting commits to the ZXingObjC project. As I read through the code, I believe I found a small mistake.

I guess you want to test for `a != b` after setting a bit.