### PR TITLE
Corrected exception message in EAN8Writer

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/EAN8Writer.java
@@ -79,7 +79,7 @@ public final class EAN8Writer extends UPCEANWriter {
         break;
       default:
         throw new IllegalArgumentException(
-            "Requested contents should be 8 digits long, but got " + length);
+            "Requested contents should be 7 or 8 digits long, but got " + length);
     }
 
     checkNumeric(contents);


### PR DESCRIPTION
I am still porting commits to the ZXingObjC project. As I read through the code, I believe I found a small mistake: according to EAN13Writer, both possibilities (7 or 8 digits) should be reflected within the message.