### PR TITLE
 Avoid ArrayIndexOutOfBoundsException in BitMatrix.get()

### DIFF
--- a/core/src/main/java/com/google/zxing/common/BitMatrix.java
+++ b/core/src/main/java/com/google/zxing/common/BitMatrix.java
@@ -158,6 +158,9 @@ public final class BitMatrix implements Cloneable {
    * @return value of given bit in matrix
    */
   public boolean get(int x, int y) {
+    if (x < 0 || x >= width || y < 0 || y >= height) {
+      return false;
+    }
     int offset = y * rowSize + (x / 32);
     return ((bits[offset] >>> (x & 0x1f)) & 1) != 0;
   }

--- a/core/src/test/java/com/google/zxing/common/BitMatrixTestCase.java
+++ b/core/src/test/java/com/google/zxing/common/BitMatrixTestCase.java
@@ -43,6 +43,10 @@ public final class BitMatrixTestCase extends Assert {
         assertEquals(y * x % 3 == 0, matrix.get(x, y));
       }
     }
+    assertFalse(matrix.get(-1, 0));
+    assertFalse(matrix.get(0, -1));
+    assertFalse(matrix.get(33, 0));
+    assertFalse(matrix.get(0, 33));
   }
 
   @Test


### PR DESCRIPTION
The pixel on out side of the image can be assumed white.

ref: [makiuchi-d/gozxing/pull/9](/makiuchi-d/gozxing/pull/9)

