### PR TITLE
Optimize code width calculation in Code39Writer

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/Code39Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/Code39Writer.java
@@ -64,14 +64,7 @@ public final class Code39Writer extends OneDimensionalCodeWriter {
     }
 
     int[] widths = new int[9];
-    int codeWidth = 24 + 1 + length;
-    for (int i = 0; i < length; i++) {
-      int indexInString = Code39Reader.ALPHABET_STRING.indexOf(contents.charAt(i));
-      toIntArray(Code39Reader.CHARACTER_ENCODINGS[indexInString], widths);
-      for (int width : widths) {
-        codeWidth += width;
-      }
-    }
+    int codeWidth = 24 + 1 + (13 * length);
     boolean[] result = new boolean[codeWidth];
     toIntArray(Code39Reader.ASTERISK_ENCODING, widths);
     int pos = appendPattern(result, 0, widths, true);


### PR DESCRIPTION
Every code39 character has 9 bars containing 3 wide bars, and separated by a white bar.
`(9-3)*1 + 3*2 + 1 = 13`