### PR TITLE
Continue in codeset A when character encoded single number or FNC1-4 in Code128Writer

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/Code128Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/Code128Writer.java
@@ -238,8 +238,8 @@ public final class Code128Writer extends OneDimensionalCodeWriter {
     if (lookahead == CType.UNCODABLE) {
       if (start < value.length()) {
         char c = value.charAt(start);
-        if (c < ' ' || (oldCode == CODE_CODE_A && c < '`')) {
-          // can continue in code A, encodes ASCII 0 to 95
+        if (c < ' ' || (oldCode == CODE_CODE_A && (c < '`' || (c >= ESCAPE_FNC_1 && c <= ESCAPE_FNC_4)))) {
+          // can continue in code A, encodes ASCII 0 to 95 or FNC1 to FNC4
           return CODE_CODE_A;
         }
       }

--- a/core/src/main/java/com/google/zxing/oned/Code128Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/Code128Writer.java
@@ -245,6 +245,9 @@ public final class Code128Writer extends OneDimensionalCodeWriter {
       }
       return CODE_CODE_B; // no choice
     }
+    if (oldCode == CODE_CODE_A && lookahead == CType.FNC_1) {
+      return CODE_CODE_A;
+    }
     if (oldCode == CODE_CODE_C) { // can continue in code C
       return CODE_CODE_C;
     }

--- a/core/src/main/java/com/google/zxing/oned/Code128Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/Code128Writer.java
@@ -233,6 +233,9 @@ public final class Code128Writer extends OneDimensionalCodeWriter {
   private static int chooseCode(CharSequence value, int start, int oldCode) {
     CType lookahead = findCType(value, start);
     if (lookahead == CType.ONE_DIGIT) {
+       if (oldCode == CODE_CODE_A) {
+         return CODE_CODE_A;
+       }
        return CODE_CODE_B;
     }
     if (lookahead == CType.UNCODABLE) {

--- a/core/src/test/java/com/google/zxing/oned/Code128WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/Code128WriterTestCase.java
@@ -116,12 +116,12 @@ public class Code128WriterTestCase extends Assert {
   }
 
   @Test
-  public void testEncodeWithFunc4InCodesetA() throws Exception {
-    String toEncode = "\n" + "\u00f4" + "\n";
+  public void testEncodeWithFunc1And4InCodesetA() throws Exception {
+    String toEncode = "\n" + "\u00f1" + "\u00f4" + "\n";
 
     String LF = "10000110010";
 
-    String expected = QUIET_SPACE + START_CODE_A + LF + FNC4A + LF + "11110100100" + STOP + QUIET_SPACE;
+    String expected = QUIET_SPACE + START_CODE_A + LF + FNC1 + FNC4A + LF + "11011101110" + STOP + QUIET_SPACE;
 
     BitMatrix result = writer.encode(toEncode, BarcodeFormat.CODE_128, 0, 0);
 

--- a/core/src/test/java/com/google/zxing/oned/Code128WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/Code128WriterTestCase.java
@@ -45,6 +45,7 @@ public class Code128WriterTestCase extends Assert {
   private static final String SWITCH_CODE_B = "10111101110";
   private static final String QUIET_SPACE = "00000";
   private static final String STOP = "1100011101011";
+  private static final String LF = "10000110010";
 
   private Writer writer;
   private Code128Reader reader;
@@ -116,12 +117,10 @@ public class Code128WriterTestCase extends Assert {
   }
 
   @Test
-  public void testEncodeWithFunc1And4InCodesetA() throws Exception {
-    String toEncode = "\n" + "\u00f1" + "\u00f4" + "\n";
+  public void testEncodeWithFncsAndNumberInCodesetA() throws Exception {
+    String toEncode = "\n" + "\u00f1" + "\u00f4" + "1" + "\n";
 
-    String LF = "10000110010";
-
-    String expected = QUIET_SPACE + START_CODE_A + LF + FNC1 + FNC4A + LF + "11011101110" + STOP + QUIET_SPACE;
+    String expected = QUIET_SPACE + START_CODE_A + LF + FNC1 + FNC4A + "10011100110" + LF + "10101111000" + STOP + QUIET_SPACE;
 
     BitMatrix result = writer.encode(toEncode, BarcodeFormat.CODE_128, 0, 0);
 

--- a/core/src/test/java/com/google/zxing/oned/Code128WriterTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/Code128WriterTestCase.java
@@ -36,7 +36,8 @@ public class Code128WriterTestCase extends Assert {
   private static final String FNC1 = "11110101110";
   private static final String FNC2 = "11110101000";
   private static final String FNC3 = "10111100010";
-  private static final String FNC4 = "10111101110";
+  private static final String FNC4A = "11101011110";
+  private static final String FNC4B = "10111101110";
   private static final String START_CODE_A = "11010000100";
   private static final String START_CODE_B = "11010010000";
   private static final String START_CODE_C = "11010011100";
@@ -106,14 +107,29 @@ public class Code128WriterTestCase extends Assert {
   public void testEncodeWithFunc4() throws WriterException {
     String toEncode = "\u00f4" + "123";
     //                                                       "1"            "2"             "3"          check digit 59
-    String expected = QUIET_SPACE + START_CODE_B + FNC4 + "10011100110" + "11001110010" + "11001011100" + "11100011010" + STOP + QUIET_SPACE;
+    String expected = QUIET_SPACE + START_CODE_B + FNC4B + "10011100110" + "11001110010" + "11001011100" + "11100011010" + STOP + QUIET_SPACE;
 
     BitMatrix result = writer.encode(toEncode, BarcodeFormat.CODE_128, 0, 0);
 
     String actual = BitMatrixTestCase.matrixToString(result);
     assertEquals(expected, actual);
   }
-  
+
+  @Test
+  public void testEncodeWithFunc4InCodesetA() throws Exception {
+    String toEncode = "\n" + "\u00f4" + "\n";
+
+    String LF = "10000110010";
+
+    String expected = QUIET_SPACE + START_CODE_A + LF + FNC4A + LF + "11110100100" + STOP + QUIET_SPACE;
+
+    BitMatrix result = writer.encode(toEncode, BarcodeFormat.CODE_128, 0, 0);
+
+    String actual = BitMatrixTestCase.matrixToString(result);
+
+    assertEquals(expected, actual);
+  }
+
   @Test
   public void testEncodeSwitchBetweenCodesetsAAndB() throws Exception {
     // start with A switch to B and back to A


### PR DESCRIPTION
The string `"\n\u00f4\n" (LF FNC4 LF)` should be encoded to:
`START_CODE_A + LF + FNC4A + LF + checksum + STOP`
but got:
`START_CODE_A + LF + SWITCH_CODE_B + FNC4B + SWITCH_CODE_A + LF + checksum + STOP`.

It should be able to continue in codeset A when character encoded FNC4.
Also single number and FNC1-3 are continuable.