### PR TITLE
Avoid book search crash on invalid intent

### DIFF
--- a/android/src/com/google/zxing/client/android/book/SearchBookContentsActivity.java
+++ b/android/src/com/google/zxing/client/android/book/SearchBookContentsActivity.java
@@ -97,6 +97,11 @@ public final class SearchBookContentsActivity extends Activity {
     }
 
     isbn = intent.getStringExtra(Intents.SearchBookContents.ISBN);
+    if (isbn == null) {
+      finish();
+      return;
+    }
+
     if (LocaleManager.isBookSearchUrl(isbn)) {
       setTitle(getString(R.string.sbc_name));
     } else {


### PR DESCRIPTION
Reproducible with

`Intent i = new Intent("com.google.zxing.client.android.SEARCH_BOOK_CONTENTS");
startActivity(i);`