### PR TITLE
Remove duplicate results when it has structured append header.

### DIFF
--- a/core/src/main/java/com/google/zxing/multi/qrcode/QRCodeMultiReader.java
+++ b/core/src/main/java/com/google/zxing/multi/qrcode/QRCodeMultiReader.java
@@ -96,7 +96,7 @@ public final class QRCodeMultiReader extends QRCodeReader implements MultipleBar
     }
   }
 
-  private static List<Result> processStructuredAppend(List<Result> results) {
+  static List<Result> processStructuredAppend(List<Result> results) {
     boolean hasSA = false;
 
     // first, check, if there is at least on SA result in the list
@@ -114,9 +114,10 @@ public final class QRCodeMultiReader extends QRCodeReader implements MultipleBar
     List<Result> newResults = new ArrayList<>();
     List<Result> saResults = new ArrayList<>();
     for (Result result : results) {
-      newResults.add(result);
       if (result.getResultMetadata().containsKey(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE)) {
         saResults.add(result);
+      } else {
+        newResults.add(result);
       }
     }
     // sort and concatenate the SA list items

--- a/core/src/test/java/com/google/zxing/multi/qrcode/MultiQRCodeTestCase.java
+++ b/core/src/test/java/com/google/zxing/multi/qrcode/MultiQRCodeTestCase.java
@@ -79,11 +79,11 @@ public final class MultiQRCodeTestCase extends Assert {
     Result sa1 = new Result("SA1", new byte[]{}, new ResultPoint[]{}, BarcodeFormat.QR_CODE);
     Result sa2 = new Result("SA2", new byte[]{}, new ResultPoint[]{}, BarcodeFormat.QR_CODE);
     Result sa3 = new Result("SA3", new byte[]{}, new ResultPoint[]{}, BarcodeFormat.QR_CODE);
-    sa1.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (0<<4)+2);
+    sa1.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (0 << 4) + 2);
     sa1.putMetadata(ResultMetadataType.ERROR_CORRECTION_LEVEL, "L");
-    sa2.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (1<<4)+2);
+    sa2.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (1 << 4) + 2);
     sa2.putMetadata(ResultMetadataType.ERROR_CORRECTION_LEVEL, "L");
-    sa3.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (2<<4)+2);
+    sa3.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (2 << 4) + 2);
     sa3.putMetadata(ResultMetadataType.ERROR_CORRECTION_LEVEL, "L");
 
     Result nsa = new Result("NotSA", new byte[]{}, new ResultPoint[]{}, BarcodeFormat.QR_CODE);

--- a/core/src/test/java/com/google/zxing/multi/qrcode/MultiQRCodeTestCase.java
+++ b/core/src/test/java/com/google/zxing/multi/qrcode/MultiQRCodeTestCase.java
@@ -19,8 +19,10 @@ package com.google.zxing.multi.qrcode;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import com.google.zxing.BarcodeFormat;
@@ -29,9 +31,11 @@ import com.google.zxing.BufferedImageLuminanceSource;
 import com.google.zxing.LuminanceSource;
 import com.google.zxing.Result;
 import com.google.zxing.ResultMetadataType;
+import com.google.zxing.ResultPoint;
 import com.google.zxing.common.AbstractBlackBoxTestCase;
 import com.google.zxing.common.HybridBinarizer;
 import com.google.zxing.multi.MultipleBarcodeReader;
+import com.google.zxing.multi.qrcode.QRCodeMultiReader;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -70,4 +74,38 @@ public final class MultiQRCodeTestCase extends Assert {
     assertEquals(expectedContents, barcodeContents);
   }
 
+  @Test
+  public void testProcessStructuredAppend() {
+    Result sa1 = new Result("SA1", new byte[]{}, new ResultPoint[]{}, BarcodeFormat.QR_CODE);
+    Result sa2 = new Result("SA2", new byte[]{}, new ResultPoint[]{}, BarcodeFormat.QR_CODE);
+    Result sa3 = new Result("SA3", new byte[]{}, new ResultPoint[]{}, BarcodeFormat.QR_CODE);
+    sa1.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (0<<4)+2);
+    sa1.putMetadata(ResultMetadataType.ERROR_CORRECTION_LEVEL, "L");
+    sa2.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (1<<4)+2);
+    sa2.putMetadata(ResultMetadataType.ERROR_CORRECTION_LEVEL, "L");
+    sa3.putMetadata(ResultMetadataType.STRUCTURED_APPEND_SEQUENCE, (2<<4)+2);
+    sa3.putMetadata(ResultMetadataType.ERROR_CORRECTION_LEVEL, "L");
+
+    Result nsa = new Result("NotSA", new byte[]{}, new ResultPoint[]{}, BarcodeFormat.QR_CODE);
+    nsa.putMetadata(ResultMetadataType.ERROR_CORRECTION_LEVEL, "L");
+
+    List<Result> inputs = new ArrayList<>();
+    inputs.add(sa3);
+    inputs.add(sa1);
+    inputs.add(nsa);
+    inputs.add(sa2);
+
+    List<Result> results = QRCodeMultiReader.processStructuredAppend(inputs);
+    assertNotNull(results);
+    assertEquals(2, results.size());
+
+    Collection<String> barcodeContents = new HashSet<>();
+    for (Result result : results) {
+      barcodeContents.add(result.getText());
+    }
+    Collection<String> expectedContents = new HashSet<>();
+    expectedContents.add("SA1SA2SA3");
+    expectedContents.add("NotSA");
+    assertEquals(expectedContents, barcodeContents);
+  }
 }

--- a/core/src/test/java/com/google/zxing/multi/qrcode/MultiQRCodeTestCase.java
+++ b/core/src/test/java/com/google/zxing/multi/qrcode/MultiQRCodeTestCase.java
@@ -35,7 +35,6 @@ import com.google.zxing.ResultPoint;
 import com.google.zxing.common.AbstractBlackBoxTestCase;
 import com.google.zxing.common.HybridBinarizer;
 import com.google.zxing.multi.MultipleBarcodeReader;
-import com.google.zxing.multi.qrcode.QRCodeMultiReader;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
When I read QR codes which has a structured append header, The result list contains duplicated data.

ex:
![fig.22](https://user-images.githubusercontent.com/1674313/54597893-be426a80-4a7a-11e9-8999-d9e447f7d498.png)
(ISO/ICE 18004 Figure 22)
`QRCodeMultiReader.decodeMultiple` returns 5 results (each qr-code data and a combined data).
It should be just combined one, I think.

I'm no sure it is a bug or not, but I want to fix it.