### PR TITLE
core JAR Automatic-Module-Name: com.google.zxing

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,11 +81,14 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>com.google.zxing</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>
     </plugins>
-  </build>  
-  
+  </build>
+
 </project>
 


### PR DESCRIPTION
Add `Automatic-Module-Name` entry of `com.google.zxing`
to the core JAR for Java Platform Module System.

See Issue #1154 

This contribution is my original work and I license the work to the project under the project's open source license.