### PR TITLE
Improve FinderPatternFinder.selectBestPatterns

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Chang Hyun Park
 Christian Brunschen (Google)
 Christoph Schulz (creatale GmbH)
 crowdin.net
+Daisuke Makiuchi
 Daniel Switkin (Google)
 Dave MacLachlan (Google)
 David Phillip Oster (Google)

--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -640,9 +640,9 @@ public class FinderPatternFinder {
 
           // a^2 + b^2 = c^2 (Pythagorean theorem), and a = b (isosceles triangle).
           // Since any right triangle satisfies the formula c^2 - b^2 - a^2 = 0,
-          // we also need to check both sides separately.
-          // The value of |c^2 - 2 * b^2| + |c^2 - 2 * a^2| increases as the triangle
-          // is dissimilar from isosceles right triangle.
+          // we need to check both two equal sides separately.
+          // The value of |c^2 - 2 * b^2| + |c^2 - 2 * a^2| increases as dissimilarity
+          // from isosceles right triangle.
           double d = Math.abs(squares[2] - 2 * squares[1]) + Math.abs(squares[2] - 2 * squares[0]);
           if (d < distortion) {
             distortion = d;

--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -621,21 +621,24 @@ public class FinderPatternFinder {
     FinderPattern[] bestPatterns = new FinderPattern[3];
 
     for (int i = 0; i < possibleCenters.size() - 2; i++) {
-      float minModuleSize = possibleCenters.get(i).getEstimatedModuleSize();
+      FinderPattern fpi = possibleCenters.get(i);
+      float minModuleSize = fpi.getEstimatedModuleSize();
 
       for (int j = i + 1; j < possibleCenters.size() - 1; j++) {
-        double squares0 = squaredDistance(possibleCenters.get(i), possibleCenters.get(j));
+        FinderPattern fpj = possibleCenters.get(j);
+        double squares0 = squaredDistance(fpi, fpj);
 
         for (int k = j + 1; k < possibleCenters.size(); k++) {
-          float maxModuleSize = possibleCenters.get(k).getEstimatedModuleSize();
+          FinderPattern fpk = possibleCenters.get(k);
+          float maxModuleSize = fpk.getEstimatedModuleSize();
           if (maxModuleSize > minModuleSize * 1.4f) {
             // module size is not similar
             continue;
           }
 
           squares[0] = squares0;
-          squares[1] = squaredDistance(possibleCenters.get(j), possibleCenters.get(k));
-          squares[2] = squaredDistance(possibleCenters.get(k), possibleCenters.get(i));
+          squares[1] = squaredDistance(fpj, fpk);
+          squares[2] = squaredDistance(fpi, fpk);
           Arrays.sort(squares);
 
           // a^2 + b^2 = c^2 (Pythagorean theorem), and a = b (isosceles triangle).
@@ -646,9 +649,9 @@ public class FinderPatternFinder {
           double d = Math.abs(squares[2] - 2 * squares[1]) + Math.abs(squares[2] - 2 * squares[0]);
           if (d < distortion) {
             distortion = d;
-            bestPatterns[0] = possibleCenters.get(i);
-            bestPatterns[1] = possibleCenters.get(j);
-            bestPatterns[2] = possibleCenters.get(k);
+            bestPatterns[0] = fpi;
+            bestPatterns[1] = fpj;
+            bestPatterns[2] = fpk;
           }
         }
       }

--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -624,7 +624,7 @@ public class FinderPatternFinder {
       float minModuleSize = possibleCenters.get(i).getEstimatedModuleSize();
 
       for (int j = i + 1; j < possibleCenters.size() - 1; j++) {
-        squares[0] = squaredDistance(possibleCenters.get(i), possibleCenters.get(j));
+        double squares0 = squaredDistance(possibleCenters.get(i), possibleCenters.get(j));
 
         for (int k = j + 1; k < possibleCenters.size(); k++) {
           float maxModuleSize = possibleCenters.get(k).getEstimatedModuleSize();
@@ -633,6 +633,7 @@ public class FinderPatternFinder {
             continue;
           }
 
+          squares[0] = squares0;
           squares[1] = squaredDistance(possibleCenters.get(j), possibleCenters.get(k));
           squares[2] = squaredDistance(possibleCenters.get(k), possibleCenters.get(i));
           Arrays.sort(squares);

--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -603,7 +603,7 @@ public class FinderPatternFinder {
 
   /**
    * @return the 3 best {@link FinderPattern}s from our list of candidates. The "best" are
-   *         those have similar module size and form a shape closer to a isoceles right triangle.
+   *         those have similar module size and form a shape closer to a isosceles right triangle.
    * @throws NotFoundException if 3 such finder patterns do not exist
    */
   private FinderPattern[] selectBestPatterns() throws NotFoundException {
@@ -638,6 +638,9 @@ public class FinderPatternFinder {
           squares[2] = squaredDistance(possibleCenters.get(k), possibleCenters.get(i));
           Arrays.sort(squares);
 
+          // From the Pythagorean theorem (a^2 + b^2 = c^2).
+          // When the triangle has a very short side, c^2 - b^2 - a^2 will be nealy 0.
+          // So we need to check each side separately.
           double d = Math.abs(squares[2] - 2 * squares[1]) + Math.abs(squares[2] - 2 * squares[0]);
           if (d < distortion) {
             distortion = d;

--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -594,7 +594,7 @@ public class FinderPatternFinder {
   /**
    * Get square of distance between a and b.
    */
-  private static double square(FinderPattern a, FinderPattern b) {
+  private static double squaredDistance(FinderPattern a, FinderPattern b) {
     double x = a.getX() - b.getX();
     double y = a.getY() - b.getY();
     return x * x + y * y;
@@ -615,7 +615,7 @@ public class FinderPatternFinder {
 
     Collections.sort(possibleCenters, new EstimatedModuleComparator());
 
-    double distotion = Double.MAX_VALUE;
+    double distortion = Double.MAX_VALUE;
     double[] squares = new double[3];
     FinderPattern[] bestPatterns = new FinderPattern[3];
 
@@ -629,14 +629,14 @@ public class FinderPatternFinder {
             continue;
           }
 
-          squares[0] = square(possibleCenters.get(i), possibleCenters.get(j));
-          squares[1] = square(possibleCenters.get(j), possibleCenters.get(k));
-          squares[2] = square(possibleCenters.get(k), possibleCenters.get(i));
+          squares[0] = squaredDistance(possibleCenters.get(i), possibleCenters.get(j));
+          squares[1] = squaredDistance(possibleCenters.get(j), possibleCenters.get(k));
+          squares[2] = squaredDistance(possibleCenters.get(k), possibleCenters.get(i));
           Arrays.sort(squares);
 
           double d = Math.abs(squares[2] - 2 * squares[1]) + Math.abs(squares[2] - 2 * squares[0]);
-          if (d < distotion) {
-            distotion = d;
+          if (d < distortion) {
+            distortion = d;
             bestPatterns[0] = possibleCenters.get(i);
             bestPatterns[1] = possibleCenters.get(j);
             bestPatterns[2] = possibleCenters.get(k);
@@ -645,7 +645,7 @@ public class FinderPatternFinder {
       }
     }
 
-    if (distotion == Double.MAX_VALUE) {
+    if (distortion == Double.MAX_VALUE) {
         throw NotFoundException.getNotFoundInstance();
     }
 

--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -41,6 +41,7 @@ import java.util.Map;
 public class FinderPatternFinder {
 
   private static final int CENTER_QUORUM = 2;
+  private static final EstimatedModuleComparator moduleComparator = new EstimatedModuleComparator();
   protected static final int MIN_SKIP = 3; // 1 pixel/module times 3 modules/center
   protected static final int MAX_MODULES = 97; // support up to version 20 for mobile clients
 
@@ -613,7 +614,7 @@ public class FinderPatternFinder {
       throw NotFoundException.getNotFoundInstance();
     }
 
-    Collections.sort(possibleCenters, new EstimatedModuleComparator());
+    Collections.sort(possibleCenters, moduleComparator);
 
     double distortion = Double.MAX_VALUE;
     double[] squares = new double[3];

--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -638,9 +638,11 @@ public class FinderPatternFinder {
           squares[2] = squaredDistance(possibleCenters.get(k), possibleCenters.get(i));
           Arrays.sort(squares);
 
-          // From the Pythagorean theorem (a^2 + b^2 = c^2).
-          // When the triangle has a very short side, c^2 - b^2 - a^2 will be nealy 0.
-          // So we need to check each side separately.
+          // a^2 + b^2 = c^2 (Pythagorean theorem), and a = b (isosceles triangle).
+          // Since any right triangle satisfies the formula c^2 - b^2 - a^2 = 0,
+          // we also need to check both sides separately.
+          // The value of |c^2 - 2 * b^2| + |c^2 - 2 * a^2| increases as the triangle
+          // is dissimilar from isosceles right triangle.
           double d = Math.abs(squares[2] - 2 * squares[1]) + Math.abs(squares[2] - 2 * squares[0]);
           if (d < distortion) {
             distortion = d;

--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -621,16 +621,18 @@ public class FinderPatternFinder {
     FinderPattern[] bestPatterns = new FinderPattern[3];
 
     for (int i = 0; i < possibleCenters.size() - 2; i++) {
+      float minModuleSize = possibleCenters.get(i).getEstimatedModuleSize();
+
       for (int j = i + 1; j < possibleCenters.size() - 1; j++) {
+        squares[0] = squaredDistance(possibleCenters.get(i), possibleCenters.get(j));
+
         for (int k = j + 1; k < possibleCenters.size(); k++) {
-          float minModuleSize = possibleCenters.get(i).getEstimatedModuleSize();
           float maxModuleSize = possibleCenters.get(k).getEstimatedModuleSize();
           if (maxModuleSize > minModuleSize * 1.4f) {
             // module size is not similar
             continue;
           }
 
-          squares[0] = squaredDistance(possibleCenters.get(i), possibleCenters.get(j));
           squares[1] = squaredDistance(possibleCenters.get(j), possibleCenters.get(k));
           squares[2] = squaredDistance(possibleCenters.get(k), possibleCenters.get(i));
           Arrays.sort(squares);

--- a/core/src/test/java/com/google/zxing/qrcode/QRCodeBlackBox2TestCase.java
+++ b/core/src/test/java/com/google/zxing/qrcode/QRCodeBlackBox2TestCase.java
@@ -28,7 +28,7 @@ public final class QRCodeBlackBox2TestCase extends AbstractBlackBoxTestCase {
   public QRCodeBlackBox2TestCase() {
     super("src/test/resources/blackbox/qrcode-2", new MultiFormatReader(), BarcodeFormat.QR_CODE);
     addTest(31, 31, 0.0f);
-    addTest(29, 29, 90.0f);
+    addTest(30, 30, 90.0f);
     addTest(30, 30, 180.0f);
     addTest(30, 30, 270.0f);
   }


### PR DESCRIPTION
I rewrote the `FinderPatternFinder.selectBestPatterns()`.
I got a better score on blackbox test 2, and same scores on other blackbox tests.

In addition, this improvement makes some QR-codes readable which reported in #1157 and #1144.