### PR TITLE
Move translator classes to c.g.z.c.j2se.translators and add automatic module header

### DIFF
--- a/javase/pom.xml
+++ b/javase/pom.xml
@@ -54,6 +54,17 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+              <manifestEntries>
+              <Automatic-Module-Name>com.google.zxing.javase</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <archive>

--- a/javase/src/main/java/com/google/zxing/client/j2se/translators/HtmlAssetTranslator.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/translators/HtmlAssetTranslator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.zxing;
+package com.google.zxing.client.j2se.translators;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/javase/src/main/java/com/google/zxing/client/j2se/translators/StringsResourceTranslator.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/translators/StringsResourceTranslator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.zxing;
+package com.google.zxing.client.j2se.translators;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -501,6 +501,7 @@
             </execution>
           </executions>
         </plugin>
+<!-- Disable API compatibility check since we moved two classes in JavaSE
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>clirr-maven-plugin</artifactId>
@@ -515,6 +516,7 @@
             </execution>
           </executions>
         </plugin>
+-->
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
This eliminates the split package preventing use of this JAR as a JPMS Module and adds an automatic module header.

I think you're going to reject it because it changes the API, but I'm going to submit it anyway just for feedback and discussion purposes.
