### PR TITLE
Fix handling of the second value of findFinderPattern() 

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/rss/RSS14Reader.java
+++ b/core/src/main/java/com/google/zxing/oned/rss/RSS14Reader.java
@@ -164,7 +164,8 @@ public final class RSS14Reader extends AbstractRSSReader {
         (ResultPointCallback) hints.get(DecodeHintType.NEED_RESULT_POINT_CALLBACK);
 
       if (resultPointCallback != null) {
-        float center = (startEnd[0] + startEnd[1]) / 2.0f;
+        startEnd = pattern.getStartEnd();
+        float center = (startEnd[0] + startEnd[1] - 1) / 2.0f;
         if (right) {
           // row is actually reversed
           center = row.getSize() - 1 - center;
@@ -193,7 +194,7 @@ public final class RSS14Reader extends AbstractRSSReader {
     if (outsideChar) {
       recordPatternInReverse(row, pattern.getStartEnd()[0], counters);
     } else {
-      recordPattern(row, pattern.getStartEnd()[1] + 1, counters);
+      recordPattern(row, pattern.getStartEnd()[1], counters);
       // reverse it
       for (int i = 0, j = counters.length - 1; i < j; i++, j--) {
         int temp = counters[i];

--- a/core/src/test/java/com/google/zxing/oned/rss/RSS14BlackBox2TestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/rss/RSS14BlackBox2TestCase.java
@@ -28,7 +28,7 @@ public final class RSS14BlackBox2TestCase extends AbstractBlackBoxTestCase {
   public RSS14BlackBox2TestCase() {
     super("src/test/resources/blackbox/rss14-2", new MultiFormatReader(), BarcodeFormat.RSS_14);
     addTest(4, 8, 1, 1, 0.0f);
-    addTest(2, 8, 0, 1, 180.0f);
+    addTest(3, 8, 0, 1, 180.0f);
   }
 
 }


### PR DESCRIPTION
The second value of `findFinderPattern()` points the outside pixel of the finder pattern (see [RSS14Reader.java:L301-306](/zxing/zxing/blob/6075d5b2f69f285657ff65b0abcc7c7885a44eed/core/src/main/java/com/google/zxing/oned/rss/RSS14Reader.java#L301-L306)).

I’ｍ going to fix two points in this PR.
1. `ResultPointCallback` parameter will be real center point of the finder pattern.
2.  The _inside char_ will be started from the next pixel of the finder pattern.