### PR TITLE
Resolved a crash for Lollipop (API 21) versions while Scanning QR code

### DIFF
--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -613,7 +614,7 @@ public class FinderPatternFinder {
       throw NotFoundException.getNotFoundInstance();
     }
 
-    possibleCenters.sort(moduleComparator);
+    Collections.sort(possibleCenters,moduleComparator);
 
     double distortion = Double.MAX_VALUE;
     double[] squares = new double[3];


### PR DESCRIPTION
In Lollipop versions it crashes during scan and gives following error logs:

java.lang.NoSuchMethodError: No interface method sort(Ljava/util/Comparator;)V in class Ljava/util/List; or its super classes