### PR TITLE
Default to allow focusing in continuous-picture mode

### DIFF
--- a/android/res/xml/preferences.xml
+++ b/android/res/xml/preferences.xml
@@ -116,7 +116,7 @@
   <PreferenceCategory android:title="@string/preferences_device_bug_workarounds_title">
     <CheckBoxPreference
         android:key="preferences_disable_continuous_focus"
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:title="@string/preferences_disable_continuous_focus_title"
         android:summary="@string/preferences_disable_continuous_focus_summary"/>
     <CheckBoxPreference

--- a/android/src/com/google/zxing/client/android/camera/CameraConfigurationManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraConfigurationManager.java
@@ -161,7 +161,7 @@ final class CameraConfigurationManager {
     CameraConfigurationUtils.setFocus(
         parameters,
         prefs.getBoolean(PreferencesActivity.KEY_AUTO_FOCUS, true),
-        prefs.getBoolean(PreferencesActivity.KEY_DISABLE_CONTINUOUS_FOCUS, true),
+        prefs.getBoolean(PreferencesActivity.KEY_DISABLE_CONTINUOUS_FOCUS, false),
         safeMode);
 
     if (!safeMode) {


### PR DESCRIPTION
 * This is supported on almost all devices now, and they handle this pretty
   well. Additionally, this workarounds a bug in some devices which auto mode
   will hang forever for unknown reason.