### PR TITLE
Should only use PURE_BARCODE if true.

### DIFF
--- a/core/src/main/java/com/google/zxing/datamatrix/DataMatrixReader.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/DataMatrixReader.java
@@ -64,7 +64,7 @@ public final class DataMatrixReader implements Reader {
       throws NotFoundException, ChecksumException, FormatException {
     DecoderResult decoderResult;
     ResultPoint[] points;
-    if (hints != null && hints.containsKey(DecodeHintType.PURE_BARCODE)) {
+    if (hints != null && hints.containsKey(DecodeHintType.PURE_BARCODE) && (Boolean) hints.get(DecodeHintType.PURE_BARCODE)) {
       BitMatrix bits = extractPureBits(image.getBlackMatrix());
       decoderResult = decoder.decode(bits);
       points = NO_POINTS;

--- a/core/src/main/java/com/google/zxing/qrcode/QRCodeReader.java
+++ b/core/src/main/java/com/google/zxing/qrcode/QRCodeReader.java
@@ -69,7 +69,7 @@ public class QRCodeReader implements Reader {
       throws NotFoundException, ChecksumException, FormatException {
     DecoderResult decoderResult;
     ResultPoint[] points;
-    if (hints != null && hints.containsKey(DecodeHintType.PURE_BARCODE)) {
+    if (hints != null && hints.containsKey(DecodeHintType.PURE_BARCODE) && (Boolean) hints.get(DecodeHintType.PURE_BARCODE)) {
       BitMatrix bits = extractPureBits(image.getBlackMatrix());
       decoderResult = decoder.decode(bits, hints);
       points = NO_POINTS;


### PR DESCRIPTION
Currently the core code when processing a `DataMatrixReader` or `QRCodeReader` barcode if a user was to set a `DecodedHintType.PURE_BARCODE` to `false`. The decode function would still process the decoding as if `DecodedHintType.PURE_BARCODE` was `true`.