### PR TITLE
fix compliation error

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/rss/expanded/RSSExpandedReader.java
+++ b/core/src/main/java/com/google/zxing/oned/rss/expanded/RSSExpandedReader.java
@@ -199,7 +199,7 @@ public final class RSSExpandedReader extends AbstractRSSReader {
 
     List<ExpandedPair> ps = null;
     try {
-      ps = checkRows(new ArrayList<>(), 0);
+      ps = checkRows(new ArrayList<ExpandedRow>(), 0);
     } catch (NotFoundException e) {
       // OK
     }


### PR DESCRIPTION
A compilation error occurs under Android > 5.0 at RSSExpandedReader, line 202.