### PR TITLE
add a Python wrapper to ZXing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ library implemented in Java, with ports to other languages.
 | [ZXingObjC](https://github.com/TheLevelUp/ZXingObjC)                                      | Port to Objective-C
 | [php-zxing](https://github.com/dsiddharth2/php-zxing)                                     | PHP wrapper to Zxing Java library
 | [zxing-js/library](https://github.com/zxing-js/library)                                   | TypeScript port of ZXing library
+| [pyzxing](https://github.com/ChenjieXu/pyzxing)                                           | Python wrapper to ZXing library
 
 
 ### Other related third-party open source projects


### PR DESCRIPTION
add pyzxing in ZXing-based third-party open source projects table