### PR TITLE
Update ResultParser.java

### DIFF
--- a/core/src/main/java/com/google/zxing/client/result/ResultParser.java
+++ b/core/src/main/java/com/google/zxing/client/result/ResultParser.java
@@ -228,7 +228,10 @@ public abstract class ResultParser {
             element = element.trim();
           }
           if (!element.isEmpty()) {
-            matches.add(element);
+            List<String> mailAdresses = element.split(','); // split the email adresses by comma 
+            for(String mail : mailAdresses){
+              matches.add(mail);
+            }
           }
           i++;
           more = false;


### PR DESCRIPTION
This adds the feature to have multiple receivers in MATMSG:TO: mail formatted QR-Codes
without this, the parser will not recognise QR-Codes with multiple receivers in DoCoMo format and will just parse it as text