### PR TITLE
Aztec encode with ECI for non-default character sets

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/AztecWriter.java
+++ b/core/src/main/java/com/google/zxing/aztec/AztecWriter.java
@@ -24,7 +24,6 @@ import com.google.zxing.aztec.encoder.Encoder;
 import com.google.zxing.common.BitMatrix;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -39,7 +38,7 @@ public final class AztecWriter implements Writer {
 
   @Override
   public BitMatrix encode(String contents, BarcodeFormat format, int width, int height, Map<EncodeHintType,?> hints) {
-    Charset charset = StandardCharsets.ISO_8859_1;
+    Charset charset = null; // Do not add any ECI code by default
     int eccPercent = Encoder.DEFAULT_EC_PERCENT;
     int layers = Encoder.DEFAULT_AZTEC_LAYERS;
     if (hints != null) {
@@ -62,7 +61,7 @@ public final class AztecWriter implements Writer {
     if (format != BarcodeFormat.AZTEC) {
       throw new IllegalArgumentException("Can only encode AZTEC, but got " + format);
     }
-    AztecCode aztec = Encoder.encode(contents.getBytes(charset), eccPercent, layers);
+    AztecCode aztec = Encoder.encode(contents, eccPercent, layers, charset);
     return renderResult(aztec, width, height);
   }
 

--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -177,7 +177,7 @@ public final class Decoder {
                 eci = eci * 10 + (nextDigit - 2);
               }
               CharacterSetECI charsetECI = CharacterSetECI.getCharacterSetECIByValue(eci);
-              encoding = Charset.forName(charsetECI.name());
+              encoding = charsetECI.getCharset();
           }
           // Go back to whatever mode we had been in
           shiftTable = latchTable;

--- a/core/src/main/java/com/google/zxing/aztec/encoder/HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/encoder/HighLevelEncoder.java
@@ -169,7 +169,7 @@ public final class HighLevelEncoder {
   public BitArray encode() {
     State initialState = State.INITIAL_STATE;
     if (charset != null) {
-      CharacterSetECI eci = CharacterSetECI.getCharacterSetECIByName(charset.name());
+      CharacterSetECI eci = CharacterSetECI.getCharacterSetECI(charset);
       if (null == eci) {
         throw new IllegalArgumentException("No ECI code for character set " + charset.toString());
       }

--- a/core/src/main/java/com/google/zxing/aztec/encoder/HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/encoder/HighLevelEncoder.java
@@ -17,6 +17,9 @@
 package com.google.zxing.aztec.encoder;
 
 import com.google.zxing.common.BitArray;
+import com.google.zxing.common.CharacterSetECI;
+
+import java.nio.charset.Charset;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -148,16 +151,31 @@ public final class HighLevelEncoder {
   }
 
   private final byte[] text;
+  private final Charset charset;
 
   public HighLevelEncoder(byte[] text) {
     this.text = text;
+    this.charset = null;
+  }
+
+  public HighLevelEncoder(byte[] text, Charset charset) {
+    this.text = text;
+    this.charset = charset;
   }
 
   /**
    * @return text represented by this encoder encoded as a {@link BitArray}
    */
   public BitArray encode() {
-    Collection<State> states = Collections.singletonList(State.INITIAL_STATE);
+    State initialState = State.INITIAL_STATE;
+    if (charset != null) {
+      CharacterSetECI eci = CharacterSetECI.getCharacterSetECIByName(charset.name());
+      if (null == eci) {
+        throw new IllegalArgumentException("No ECI code for character set " + charset.toString());
+      }
+      initialState = initialState.appendFLGn(eci.getValue());
+    }
+    Collection<State> states = Collections.singletonList(initialState);
     for (int index = 0; index < text.length; index++) {
       int pairCode;
       int nextChar = index + 1 < text.length ? text[index + 1] : 0;

--- a/core/src/main/java/com/google/zxing/common/CharacterSetECI.java
+++ b/core/src/main/java/com/google/zxing/common/CharacterSetECI.java
@@ -18,6 +18,8 @@ package com.google.zxing.common;
 
 import com.google.zxing.FormatException;
 
+import java.nio.charset.Charset;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -91,6 +93,19 @@ public enum CharacterSetECI {
 
   public int getValue() {
     return values[0];
+  }
+
+  public Charset getCharset() {
+    return Charset.forName(name());
+  }
+
+  /**
+   * @param charset Java character set object
+   * @return CharacterSetECI representing ECI for character encoding, or null if it is legal
+   *   but unsupported
+   */
+  public static CharacterSetECI getCharacterSetECI(Charset charset) {
+    return NAME_TO_ECI.get(charset.name());
   }
 
   /**

--- a/core/src/main/java/com/google/zxing/datamatrix/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/decoder/DecodedBitStreamParser.java
@@ -20,7 +20,7 @@ import com.google.zxing.FormatException;
 import com.google.zxing.common.BitSource;
 import com.google.zxing.common.DecoderResult;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -505,11 +505,7 @@ final class DecodedBitStreamParser {
       bytes[i] = (byte) unrandomize255State(bits.readBits(8), codewordPosition++);
     }
     byteSegments.add(bytes);
-    try {
-      result.append(new String(bytes, "ISO8859_1"));
-    } catch (UnsupportedEncodingException uee) {
-      throw new IllegalStateException("Platform does not support required encoding: " + uee);
-    }
+    result.append(new String(bytes, StandardCharsets.ISO_8859_1));
   }
 
   /**

--- a/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
@@ -125,7 +125,7 @@ final class DecodedBitStreamParser {
         case ECI_CHARSET:
           CharacterSetECI charsetECI =
               CharacterSetECI.getCharacterSetECIByValue(codewords[codeIndex++]);
-          encoding = Charset.forName(charsetECI.name());
+          encoding = charsetECI.getCharset();
           break;
         case ECI_GENERAL_PURPOSE:
           // Can't do anything with generic ECI; skip its 2 characters

--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -169,7 +169,7 @@ final class PDF417HighLevelEncoder {
     if (encoding == null) {
       encoding = DEFAULT_ENCODING;
     } else if (!DEFAULT_ENCODING.equals(encoding)) {
-      CharacterSetECI eci = CharacterSetECI.getCharacterSetECIByName(encoding.name());
+      CharacterSetECI eci = CharacterSetECI.getCharacterSetECI(encoding);
       if (eci != null) {
         encodingECI(eci.getValue(), sb);
       }

--- a/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
@@ -23,7 +23,7 @@ import com.google.zxing.common.CharacterSetECI;
 import com.google.zxing.common.DecoderResult;
 import com.google.zxing.common.StringUtils;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -173,11 +173,7 @@ final class DecodedBitStreamParser {
       count--;
     }
 
-    try {
-      result.append(new String(buffer, StringUtils.GB2312));
-    } catch (UnsupportedEncodingException ignored) {
-      throw FormatException.getFormatInstance();
-    }
+    result.append(new String(buffer, StringUtils.GB2312_CHARSET));
   }
 
   private static void decodeKanjiSegment(BitSource bits,
@@ -208,12 +204,7 @@ final class DecodedBitStreamParser {
       offset += 2;
       count--;
     }
-    // Shift_JIS may not be supported in some environments:
-    try {
-      result.append(new String(buffer, StringUtils.SHIFT_JIS));
-    } catch (UnsupportedEncodingException ignored) {
-      throw FormatException.getFormatInstance();
-    }
+    result.append(new String(buffer, StringUtils.SHIFT_JIS_CHARSET));
   }
 
   private static void decodeByteSegment(BitSource bits,
@@ -231,22 +222,18 @@ final class DecodedBitStreamParser {
     for (int i = 0; i < count; i++) {
       readBytes[i] = (byte) bits.readBits(8);
     }
-    String encoding;
+    Charset encoding;
     if (currentCharacterSetECI == null) {
       // The spec isn't clear on this mode; see
       // section 6.4.5: t does not say which encoding to assuming
       // upon decoding. I have seen ISO-8859-1 used as well as
       // Shift_JIS -- without anything like an ECI designator to
       // give a hint.
-      encoding = StringUtils.guessEncoding(readBytes, hints);
+      encoding = StringUtils.guessCharset(readBytes, hints);
     } else {
-      encoding = currentCharacterSetECI.name();
+      encoding = currentCharacterSetECI.getCharset();
     }
-    try {
-      result.append(new String(readBytes, encoding));
-    } catch (UnsupportedEncodingException ignored) {
-      throw FormatException.getFormatInstance();
-    }
+    result.append(new String(readBytes, encoding));
     byteSegments.add(readBytes);
   }
 

--- a/core/src/test/java/com/google/zxing/aztec/detector/DetectorTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/detector/DetectorTest.java
@@ -27,7 +27,6 @@ import com.google.zxing.common.DecoderResult;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,7 +61,7 @@ public final class DetectorTest extends Assert {
 
   // Test that we can tolerate errors in the parameter locator bits
   private static void testErrorInParameterLocator(String data) throws Exception {
-    AztecCode aztec = Encoder.encode(data.getBytes(StandardCharsets.ISO_8859_1), 25, Encoder.DEFAULT_AZTEC_LAYERS);
+    AztecCode aztec = Encoder.encode(data, 25, Encoder.DEFAULT_AZTEC_LAYERS);
     Random random = new Random(aztec.getMatrix().hashCode());   // pseudo-random, but deterministic
     int layers = aztec.getLayers();
     boolean compact = aztec.isCompact();

--- a/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
@@ -136,6 +136,7 @@ public final class EncoderTest extends Assert {
     testWriter("\u20AC 1 sample data.", "UTF-8", 100, true, 3);
     testWriter("\u20AC 1 sample data.", "UTF-8", 300, true, 4);
     testWriter("\u20AC 1 sample data.", "UTF-8", 500, false, 5);
+    testWriter("The capital of Japan is named \u6771\u4EAC.", "Shift_JIS", 25, true, 3);
     // Test AztecWriter defaults
     String data = "In ut magna vel mauris malesuada";
     AztecWriter writer = new AztecWriter();
@@ -420,7 +421,7 @@ public final class EncoderTest extends Assert {
 
   @Test
   public void testUserSpecifiedLayers() throws FormatException {
-    byte[] alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(StandardCharsets.ISO_8859_1);
+    String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     AztecCode aztec = Encoder.encode(alphabet, 25, -2);
     assertEquals(2, aztec.getLayers());
     assertTrue(aztec.isCompact());
@@ -451,22 +452,21 @@ public final class EncoderTest extends Assert {
     String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     // encodes as 26 * 5 * 4 = 520 bits of data
     String alphabet4 = alphabet + alphabet + alphabet + alphabet;
-    byte[] data = alphabet4.getBytes(StandardCharsets.ISO_8859_1);
     try {
-      Encoder.encode(data, 0, -4);
+      Encoder.encode(alphabet4, 0, -4);
       fail("Encode should have failed.  Text can't fit in 1-layer compact");
     } catch (IllegalArgumentException expected) {
       // continue
     }
 
     // If we just try to encode it normally, it will go to a non-compact 4 layer
-    AztecCode aztecCode = Encoder.encode(data, 0, Encoder.DEFAULT_AZTEC_LAYERS);
+    AztecCode aztecCode = Encoder.encode(alphabet4, 0, Encoder.DEFAULT_AZTEC_LAYERS);
     assertFalse(aztecCode.isCompact());
     assertEquals(4, aztecCode.getLayers());
 
     // But shortening the string to 100 bytes (500 bits of data), compact works fine, even if we
     // include more error checking.
-    aztecCode = Encoder.encode(alphabet4.substring(0, 100).getBytes(StandardCharsets.ISO_8859_1), 10, Encoder.DEFAULT_AZTEC_LAYERS);
+    aztecCode = Encoder.encode(alphabet4.substring(0, 100), 10, Encoder.DEFAULT_AZTEC_LAYERS);
     assertTrue(aztecCode.isCompact());
     assertEquals(4, aztecCode.getLayers());
   }
@@ -474,7 +474,7 @@ public final class EncoderTest extends Assert {
   // Helper routines
 
   private static void testEncode(String data, boolean compact, int layers, String expected) throws FormatException {
-    AztecCode aztec = Encoder.encode(data.getBytes(StandardCharsets.ISO_8859_1), 33, Encoder.DEFAULT_AZTEC_LAYERS);
+    AztecCode aztec = Encoder.encode(data, 33, Encoder.DEFAULT_AZTEC_LAYERS);
     assertEquals("Unexpected symbol format (compact)", compact, aztec.isCompact());
     assertEquals("Unexpected nr. of layers", layers, aztec.getLayers());
     BitMatrix matrix = aztec.getMatrix();
@@ -482,7 +482,7 @@ public final class EncoderTest extends Assert {
   }
 
   private static void testEncodeDecode(String data, boolean compact, int layers) throws Exception {
-    AztecCode aztec = Encoder.encode(data.getBytes(StandardCharsets.ISO_8859_1), 25, Encoder.DEFAULT_AZTEC_LAYERS);
+    AztecCode aztec = Encoder.encode(data, 25, Encoder.DEFAULT_AZTEC_LAYERS);
     assertEquals("Unexpected symbol format (compact)", compact, aztec.isCompact());
     assertEquals("Unexpected nr. of layers", layers, aztec.getLayers());
     BitMatrix matrix = aztec.getMatrix();

--- a/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
@@ -36,9 +36,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 /**
  * Aztec 2D generator unit tests.
  *
@@ -47,6 +44,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public final class EncoderTest extends Assert {
 
+  private static final Charset ISO_8859_1 = StandardCharsets.ISO_8859_1;
+  private static final Charset UTF_8 = StandardCharsets.UTF_8;
   private static final Charset SHIFT_JIS = Charset.forName("Shift_JIS");
   private static final Charset ISO_8859_15 = Charset.forName("ISO-8859-15");
   private static final Charset WINDOWS_1252 = Charset.forName("Windows-1252");
@@ -516,13 +515,13 @@ public final class EncoderTest extends Assert {
     // Perform an encode-decode round-trip because it can be lossy.
     Map<EncodeHintType,Object> hints = new EnumMap<>(EncodeHintType.class);
     if (null != charset) {
-        hints.put(EncodeHintType.CHARACTER_SET, charset);
+        hints.put(EncodeHintType.CHARACTER_SET, charset.name());
     }
     hints.put(EncodeHintType.ERROR_CORRECTION, eccPercent);
     AztecWriter writer = new AztecWriter();
     BitMatrix matrix = writer.encode(data, BarcodeFormat.AZTEC, 0, 0, hints);
     AztecCode aztec = Encoder.encode(data, eccPercent,
-        Encoder.DEFAULT_AZTEC_LAYERS, charset == null ? null : Charset.forName(charset));
+        Encoder.DEFAULT_AZTEC_LAYERS, charset);
     assertEquals("Unexpected symbol format (compact)", compact, aztec.isCompact());
     assertEquals("Unexpected nr. of layers", layers, aztec.getLayers());
     BitMatrix matrix2 = aztec.getMatrix();

--- a/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/encoder/EncoderTest.java
@@ -36,6 +36,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Aztec 2D generator unit tests.
  *
@@ -43,6 +46,10 @@ import java.util.regex.Pattern;
  * @author Frank Yellin
  */
 public final class EncoderTest extends Assert {
+
+  private static final Charset SHIFT_JIS = Charset.forName("Shift_JIS");
+  private static final Charset ISO_8859_15 = Charset.forName("ISO-8859-15");
+  private static final Charset WINDOWS_1252 = Charset.forName("Windows-1252");
 
   private static final Pattern DOTX = Pattern.compile("[^.X]");
   private static final Pattern SPACES = Pattern.compile("\\s+");
@@ -128,15 +135,15 @@ public final class EncoderTest extends Assert {
 
   @Test
   public void testAztecWriter() throws Exception {
-    testWriter("Espa\u00F1ol", null, 25, true, 1);                     // Without ECI (implicit ISO-8859-1)
-    testWriter("Espa\u00F1ol", "ISO-8859-1", 25, true, 1);             // Explicit ISO-8859-1
-    testWriter("\u20AC 1 sample data.", "Windows-1252", 25, true, 2);  // Standard ISO-8859-1 cannot encode Euro symbol; Windows-1252 superset can
-    testWriter("\u20AC 1 sample data.", "ISO-8859-15", 25, true, 2);
-    testWriter("\u20AC 1 sample data.", "UTF-8", 25, true, 2);
-    testWriter("\u20AC 1 sample data.", "UTF-8", 100, true, 3);
-    testWriter("\u20AC 1 sample data.", "UTF-8", 300, true, 4);
-    testWriter("\u20AC 1 sample data.", "UTF-8", 500, false, 5);
-    testWriter("The capital of Japan is named \u6771\u4EAC.", "Shift_JIS", 25, true, 3);
+    testWriter("Espa\u00F1ol", null, 25, true, 1);                   // Without ECI (implicit ISO-8859-1)
+    testWriter("Espa\u00F1ol", ISO_8859_1, 25, true, 1);             // Explicit ISO-8859-1
+    testWriter("\u20AC 1 sample data.", WINDOWS_1252, 25, true, 2);  // Standard ISO-8859-1 cannot encode Euro symbol; Windows-1252 superset can
+    testWriter("\u20AC 1 sample data.", ISO_8859_15, 25, true, 2);
+    testWriter("\u20AC 1 sample data.", UTF_8, 25, true, 2);
+    testWriter("\u20AC 1 sample data.", UTF_8, 100, true, 3);
+    testWriter("\u20AC 1 sample data.", UTF_8, 300, true, 4);
+    testWriter("\u20AC 1 sample data.", UTF_8, 500, false, 5);
+    testWriter("The capital of Japan is named \u6771\u4EAC.", SHIFT_JIS, 25, true, 3);
     // Test AztecWriter defaults
     String data = "In ut magna vel mauris malesuada";
     AztecWriter writer = new AztecWriter();
@@ -502,7 +509,7 @@ public final class EncoderTest extends Assert {
   }
 
   private static void testWriter(String data,
-                                 String charset,
+                                 Charset charset,
                                  int eccPercent,
                                  boolean compact,
                                  int layers) throws FormatException {

--- a/core/src/test/java/com/google/zxing/common/StringUtilsTestCase.java
+++ b/core/src/test/java/com/google/zxing/common/StringUtilsTestCase.java
@@ -19,6 +19,7 @@ package com.google.zxing.common;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.Charset;
 
 /**
@@ -28,34 +29,42 @@ public final class StringUtilsTestCase extends Assert {
 
   @Test
   public void testShortShiftJIS1() {
-    // ÈáëÈ≠ö
-    doTest(new byte[] { (byte) 0x8b, (byte) 0xe0, (byte) 0x8b, (byte) 0x9b, }, "SJIS");
+    // 金魚
+    doTest(new byte[] { (byte) 0x8b, (byte) 0xe0, (byte) 0x8b, (byte) 0x9b, }, StringUtils.SHIFT_JIS_CHARSET, "SJIS");
   }
 
   @Test
   public void testShortISO885911() {
-    // b√•d
-    doTest(new byte[] { (byte) 0x62, (byte) 0xe5, (byte) 0x64, }, "ISO-8859-1");
+    // båd
+    doTest(new byte[] { (byte) 0x62, (byte) 0xe5, (byte) 0x64, }, StandardCharsets.ISO_8859_1, "ISO8859_1");
+  }
+
+  @Test
+  public void testShortUTF81() {
+    // Español
+    doTest(new byte[] { (byte) 0x45, (byte) 0x73, (byte) 0x70, (byte) 0x61, (byte) 0xc3,
+                        (byte) 0xb1, (byte) 0x6f, (byte) 0x6c },
+           StandardCharsets.UTF_8, "UTF8");
   }
 
   @Test
   public void testMixedShiftJIS1() {
-    // Hello Èáë!
+    // Hello 金!
     doTest(new byte[] { (byte) 0x48, (byte) 0x65, (byte) 0x6c, (byte) 0x6c, (byte) 0x6f,
                         (byte) 0x20, (byte) 0x8b, (byte) 0xe0, (byte) 0x21, },
-           "SJIS");
+           StringUtils.SHIFT_JIS_CHARSET, "SJIS");
   }
 
-  private static void doTest(byte[] bytes, String charsetName) {
-    Charset charset = Charset.forName(charsetName);
-    String guessedName = StringUtils.guessEncoding(bytes, null);
-    Charset guessedEncoding = Charset.forName(guessedName);
-    assertEquals(charset, guessedEncoding);
+  private static void doTest(byte[] bytes, Charset charset, String encoding) {
+    Charset guessedCharset = StringUtils.guessCharset(bytes, null);
+    String guessedEncoding = StringUtils.guessEncoding(bytes, null);
+    assertEquals(charset, guessedCharset);
+    assertEquals(encoding, guessedEncoding);
   }
 
   /**
    * Utility for printing out a string in given encoding as a Java statement, since it's better
-   * to write that into the Java source file rather than risk character encoding issues in the 
+   * to write that into the Java source file rather than risk character encoding issues in the
    * source file itself.
    *
    * @param args command line arguments

--- a/core/src/test/java/com/google/zxing/qrcode/encoder/EncoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/qrcode/encoder/EncoderTestCase.java
@@ -19,6 +19,7 @@ package com.google.zxing.qrcode.encoder;
 import com.google.zxing.EncodeHintType;
 import com.google.zxing.WriterException;
 import com.google.zxing.common.BitArray;
+import com.google.zxing.common.StringUtils;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 import com.google.zxing.qrcode.decoder.Mode;
 import com.google.zxing.qrcode.decoder.Version;
@@ -26,7 +27,6 @@ import com.google.zxing.qrcode.decoder.Version;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -127,7 +127,7 @@ public final class EncoderTestCase extends Assert {
           ">>\n";
     assertEquals(expected, qrCode.toString());
   }
-  
+
   @Test
   public void testEncodeWithVersion() throws WriterException {
     Map<EncodeHintType, Object> hints = new EnumMap<>(EncodeHintType.class);
@@ -135,7 +135,7 @@ public final class EncoderTestCase extends Assert {
     QRCode qrCode = Encoder.encode("ABCDEF", ErrorCorrectionLevel.H, hints);
     assertTrue(qrCode.toString().contains(" version: 7\n"));
   }
-  
+
   @Test(expected = WriterException.class)
   public void testEncodeWithVersionTooSmall() throws WriterException {
     Map<EncodeHintType, Object> hints = new EnumMap<>(EncodeHintType.class);
@@ -742,12 +742,8 @@ public final class EncoderTestCase extends Assert {
     assertEquals(expected, qrCode.toString());
   }
 
-  private static String shiftJISString(byte[] bytes) throws WriterException {
-    try {
-      return new String(bytes, "Shift_JIS");
-    } catch (UnsupportedEncodingException uee) {
-      throw new WriterException(uee.toString());
-    }
+  private static String shiftJISString(byte[] bytes) {
+    return new String(bytes, StringUtils.SHIFT_JIS_CHARSET);
   }
 
 }


### PR DESCRIPTION
Follow-up to https://github.com/zxing/zxing/pull/1328, which added charset-aware _decoding_ to Aztec Code.

* Make `AztecWriter` and `aztec.Encoder` insert ECI according to character set hint
* Add encoder and round-trip test cases using ECI (and fix an erroneous test case that only passed previously because it wasn't really doing a charset-aware decode)
* Simplify test cases to avoid unnecessary `String`/`byte[]` and `Charset`/`String` (charset name) conversions.
* Further removal of unnecessary `Charset`/`String` (charset name) conversions…
  1. First, throughout the Aztec implementation
  2. In PDF417, QR, and DataMatrix implementations too