### PR TITLE
update Fragment and Activity from androidx (not deprecated anymore)

### DIFF
--- a/android-integration/pom.xml
+++ b/android-integration/pom.xml
@@ -34,6 +34,55 @@
       <type>aar</type>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>androidx.arch.core</groupId>
+      <artifactId>core-common</artifactId>
+      <version>2.0.1</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.lifecycle</groupId>
+      <artifactId>lifecycle-viewmodel</artifactId>
+      <version>2.2.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.lifecycle</groupId>
+      <artifactId>lifecycle-livedata-core</artifactId>
+      <version>2.2.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.core</groupId>
+      <artifactId>core</artifactId>
+      <version>1.1.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.lifecycle</groupId>
+      <artifactId>lifecycle-runtime</artifactId>
+      <version>2.2.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.lifecycle</groupId>
+      <artifactId>lifecycle-viewmodel-savedstate</artifactId>
+      <version>2.2.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.annotation</groupId>
+      <artifactId>annotation</artifactId>
+      <version>1.1.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.collection</groupId>
+      <artifactId>collection</artifactId>
+      <version>1.1.0</version>
+      <type>aar</type>
+    </dependency>
+    
   </dependencies>
 
   <repositories>

--- a/android-integration/pom.xml
+++ b/android-integration/pom.xml
@@ -14,7 +14,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>android-integration</artifactId>
@@ -30,13 +31,23 @@
       <groupId>androidx.fragment</groupId>
       <artifactId>fragment</artifactId>
       <version>1.2.5</version>
+      <type>aar</type>
     </dependency>
     <dependency>
       <groupId>androidx.activity</groupId>
       <artifactId>activity</artifactId>
       <version>1.1.0</version>
+      <type>aar</type>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>google-maven-central</id>
+      <name>Google Maven</name>
+      <url>https://maven.google.com</url>
+    </repository>
+  </repositories>
 
   <build>
     <pluginManagement>

--- a/android-integration/pom.xml
+++ b/android-integration/pom.xml
@@ -33,6 +33,40 @@
       <version>1.2.5</version>
       <type>aar</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>androidx.arch.core</groupId>
+          <artifactId>core-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>androidx.lifecycle</groupId>
+          <artifactId>lifecycle-viewmodel</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>androidx.lifecycle</groupId>
+          <artifactId>lifecycle-livedata-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>androidx.core</groupId>
+          <artifactId>core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>androidx.lifecycle</groupId>
+          <artifactId>lifecycle-runtime</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>androidx.lifecycle</groupId>
+          <artifactId>lifecycle-viewmodel-savedstate</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>androidx.annotation</groupId>
+          <artifactId>annotation</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>androidx.collection</groupId>
+          <artifactId>collection</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>androidx.arch.core</groupId>

--- a/android-integration/pom.xml
+++ b/android-integration/pom.xml
@@ -38,7 +38,7 @@
 
   <repositories>
     <repository>
-      <id>google-maven-central</id>
+      <id>google-maven-repo</id>
       <name>Google Maven</name>
       <url>https://maven.google.com</url>
     </repository>

--- a/android-integration/pom.xml
+++ b/android-integration/pom.xml
@@ -38,7 +38,6 @@
       <groupId>androidx.arch.core</groupId>
       <artifactId>core-common</artifactId>
       <version>2.0.1</version>
-      <type>aar</type>
     </dependency>
     <dependency>
       <groupId>androidx.lifecycle</groupId>
@@ -74,15 +73,12 @@
       <groupId>androidx.annotation</groupId>
       <artifactId>annotation</artifactId>
       <version>1.1.0</version>
-      <type>aar</type>
     </dependency>
     <dependency>
       <groupId>androidx.collection</groupId>
       <artifactId>collection</artifactId>
       <version>1.1.0</version>
-      <type>aar</type>
     </dependency>
-    
   </dependencies>
 
   <repositories>

--- a/android-integration/pom.xml
+++ b/android-integration/pom.xml
@@ -32,12 +32,7 @@
       <artifactId>fragment</artifactId>
       <version>1.2.5</version>
       <type>aar</type>
-    </dependency>
-    <dependency>
-      <groupId>androidx.activity</groupId>
-      <artifactId>activity</artifactId>
-      <version>1.1.0</version>
-      <type>aar</type>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/android-integration/pom.xml
+++ b/android-integration/pom.xml
@@ -26,6 +26,16 @@
       <groupId>com.google.android</groupId>
       <artifactId>android</artifactId>
     </dependency>
+    <dependency>
+      <groupId>androidx.fragment</groupId>
+      <artifactId>fragment</artifactId>
+      <version>1.2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>androidx.activity</groupId>
+      <artifactId>activity</artifactId>
+      <version>1.1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/android-integration/src/main/java/com/google/zxing/integration/android/IntentIntegrator.java
+++ b/android-integration/src/main/java/com/google/zxing/integration/android/IntentIntegrator.java
@@ -23,9 +23,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import android.app.Activity;
+import androidx.Activity;
 import android.app.AlertDialog;
-import android.app.Fragment;
+import androidx.fragment.app.Fragment;
 import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;


### PR DESCRIPTION
`Fragment` and `Activity` classes used in android-integration are the deprecated ones. 

The goal of this PR is to update them to androidx libraries