### PR TITLE
Introduce BinaryBitmap parent, AbstractBinaryBitmap

### DIFF
--- a/core/src/main/java/com/google/zxing/AbstractBinaryBitmap.java
+++ b/core/src/main/java/com/google/zxing/AbstractBinaryBitmap.java
@@ -1,0 +1,96 @@
+package com.google.zxing;
+
+import com.google.zxing.common.BitArray;
+import com.google.zxing.common.BitMatrix;
+
+/**
+ * Represents an image bitmap of 1 bit data values.
+ * Reader objects accept AbstractBinaryBitmaps and attempt to decode it.
+ *
+ * @see BinaryBitmap for default implementation
+ */
+public interface AbstractBinaryBitmap {
+
+  /**
+   * @return The width of the bitmap.
+   */
+  int getWidth();
+
+  /**
+   * @return The height of the bitmap.
+   */
+  int getHeight();
+
+  /**
+   * Converts one row of luminance data to 1 bit data. May actually do the conversion, or return
+   * cached data. Callers should assume this method is expensive and call it as seldom as possible.
+   * This method is intended for decoding 1D barcodes and may choose to apply sharpening.
+   *
+   * @param y The row to fetch, which must be in [0, bitmap height)
+   * @param row An optional preallocated array. If null or too small, it will be ignored.
+   *            If used, the Binarizer will call BitArray.clear(). Always use the returned object.
+   * @return The array of bits for this row (true means black).
+   * @throws NotFoundException if row can't be binarized
+   */
+  BitArray getBlackRow(int y, BitArray row) throws NotFoundException;
+
+  /**
+   * Converts a 2D array of luminance data to 1 bit. As above, assume this method is expensive
+   * and do not call it repeatedly. This method is intended for decoding 2D barcodes and may or
+   * may not apply sharpening. Therefore, a row from this matrix may not be identical to one
+   * fetched using getBlackRow(), so don't mix and match between them.
+   *
+   * @return The 2D array of bits for the image (true means black).
+   * @throws NotFoundException if image can't be binarized to make a matrix
+   */
+  BitMatrix getBlackMatrix() throws NotFoundException;
+
+  /**
+   * @return Whether this bitmap can be cropped.
+   */
+  boolean isCropSupported();
+
+  /**
+   * Returns a new object with cropped image data. Implementations may keep a reference to the
+   * original data rather than a copy. Only callable if isCropSupported() is true.
+   *
+   * @param left The left coordinate, which must be in [0,getWidth())
+   * @param top The top coordinate, which must be in [0,getHeight())
+   * @param width The width of the rectangle to crop.
+   * @param height The height of the rectangle to crop.
+   * @return A cropped version of this object.
+   */
+  AbstractBinaryBitmap crop(int left, int top, int width, int height);
+
+  /**
+   * @return Whether this bitmap supports counter-clockwise rotation by 45 and 90 degrees.
+   */
+  boolean isRotateSupported();
+
+  /**
+   * @return Whether this bitmap supports counter-clockwise rotation by 90 degrees.
+   */
+  boolean isRotate90Supported();
+
+  /**
+   * @return Whether this bitmap supports counter-clockwise rotation by 45 degrees.
+   */
+  boolean isRotate45Supported();
+
+  /**
+   * Returns a new object with rotated image data by 90 degrees counterclockwise.
+   * Only callable if {@link #isRotate90Supported()} is true.
+   *
+   * @return A rotated version of this object.
+   */
+  AbstractBinaryBitmap rotateCounterClockwise();
+
+  /**
+   * Returns a new object with rotated image data by 45 degrees counterclockwise.
+   * Only callable if {@link #isRotate45Supported()} is true.
+   *
+   * @return A rotated version of this object.
+   */
+  AbstractBinaryBitmap rotateCounterClockwise45();
+
+}

--- a/core/src/main/java/com/google/zxing/BinaryBitmap.java
+++ b/core/src/main/java/com/google/zxing/BinaryBitmap.java
@@ -25,7 +25,7 @@ import com.google.zxing.common.BitMatrix;
  *
  * @author dswitkin@google.com (Daniel Switkin)
  */
-public final class BinaryBitmap {
+public final class BinaryBitmap implements AbstractBinaryBitmap {
 
   private final Binarizer binarizer;
   private BitMatrix matrix;
@@ -40,6 +40,7 @@ public final class BinaryBitmap {
   /**
    * @return The width of the bitmap.
    */
+  @Override
   public int getWidth() {
     return binarizer.getWidth();
   }
@@ -47,6 +48,7 @@ public final class BinaryBitmap {
   /**
    * @return The height of the bitmap.
    */
+  @Override
   public int getHeight() {
     return binarizer.getHeight();
   }
@@ -62,6 +64,7 @@ public final class BinaryBitmap {
    * @return The array of bits for this row (true means black).
    * @throws NotFoundException if row can't be binarized
    */
+  @Override
   public BitArray getBlackRow(int y, BitArray row) throws NotFoundException {
     return binarizer.getBlackRow(y, row);
   }
@@ -75,6 +78,7 @@ public final class BinaryBitmap {
    * @return The 2D array of bits for the image (true means black).
    * @throws NotFoundException if image can't be binarized to make a matrix
    */
+  @Override
   public BitMatrix getBlackMatrix() throws NotFoundException {
     // The matrix is created on demand the first time it is requested, then cached. There are two
     // reasons for this:
@@ -90,6 +94,7 @@ public final class BinaryBitmap {
   /**
    * @return Whether this bitmap can be cropped.
    */
+  @Override
   public boolean isCropSupported() {
     return binarizer.getLuminanceSource().isCropSupported();
   }
@@ -104,6 +109,7 @@ public final class BinaryBitmap {
    * @param height The height of the rectangle to crop.
    * @return A cropped version of this object.
    */
+  @Override
   public BinaryBitmap crop(int left, int top, int width, int height) {
     LuminanceSource newSource = binarizer.getLuminanceSource().crop(left, top, width, height);
     return new BinaryBitmap(binarizer.createBinarizer(newSource));
@@ -112,8 +118,19 @@ public final class BinaryBitmap {
   /**
    * @return Whether this bitmap supports counter-clockwise rotation.
    */
+  @Override
   public boolean isRotateSupported() {
     return binarizer.getLuminanceSource().isRotateSupported();
+  }
+
+  @Override
+  public boolean isRotate90Supported() {
+    return isRotateSupported();
+  }
+
+  @Override
+  public boolean isRotate45Supported() {
+    return isRotateSupported();
   }
 
   /**
@@ -122,6 +139,7 @@ public final class BinaryBitmap {
    *
    * @return A rotated version of this object.
    */
+  @Override
   public BinaryBitmap rotateCounterClockwise() {
     LuminanceSource newSource = binarizer.getLuminanceSource().rotateCounterClockwise();
     return new BinaryBitmap(binarizer.createBinarizer(newSource));
@@ -133,6 +151,7 @@ public final class BinaryBitmap {
    *
    * @return A rotated version of this object.
    */
+  @Override
   public BinaryBitmap rotateCounterClockwise45() {
     LuminanceSource newSource = binarizer.getLuminanceSource().rotateCounterClockwise45();
     return new BinaryBitmap(binarizer.createBinarizer(newSource));

--- a/core/src/main/java/com/google/zxing/DecodeHintType.java
+++ b/core/src/main/java/com/google/zxing/DecodeHintType.java
@@ -25,7 +25,7 @@ import java.util.List;
  *
  * @author Sean Owen
  * @author dswitkin@google.com (Daniel Switkin)
- * @see Reader#decode(BinaryBitmap,java.util.Map)
+ * @see Reader#decode(AbstractBinaryBitmap,java.util.Map)
  */
 public enum DecodeHintType {
 

--- a/core/src/main/java/com/google/zxing/MultiFormatReader.java
+++ b/core/src/main/java/com/google/zxing/MultiFormatReader.java
@@ -52,7 +52,7 @@ public final class MultiFormatReader implements Reader {
    * @throws NotFoundException Any errors which occurred
    */
   @Override
-  public Result decode(BinaryBitmap image) throws NotFoundException {
+  public Result decode(AbstractBinaryBitmap image) throws NotFoundException {
     setHints(null);
     return decodeInternal(image);
   }
@@ -66,7 +66,7 @@ public final class MultiFormatReader implements Reader {
    * @throws NotFoundException Any errors which occurred
    */
   @Override
-  public Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints) throws NotFoundException {
+  public Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints) throws NotFoundException {
     setHints(hints);
     return decodeInternal(image);
   }
@@ -79,7 +79,7 @@ public final class MultiFormatReader implements Reader {
    * @return The contents of the image
    * @throws NotFoundException Any errors which occurred
    */
-  public Result decodeWithState(BinaryBitmap image) throws NotFoundException {
+  public Result decodeWithState(AbstractBinaryBitmap image) throws NotFoundException {
     // Make sure to set up the default state so we don't crash
     if (readers == null) {
       setHints(null);
@@ -166,7 +166,7 @@ public final class MultiFormatReader implements Reader {
     }
   }
 
-  private Result decodeInternal(BinaryBitmap image) throws NotFoundException {
+  private Result decodeInternal(AbstractBinaryBitmap image) throws NotFoundException {
     if (readers != null) {
       for (Reader reader : readers) {
         try {

--- a/core/src/main/java/com/google/zxing/Reader.java
+++ b/core/src/main/java/com/google/zxing/Reader.java
@@ -41,7 +41,7 @@ public interface Reader {
    * @throws ChecksumException if a potential barcode is found but does not pass its checksum
    * @throws FormatException if a potential barcode is found but format is invalid
    */
-  Result decode(BinaryBitmap image) throws NotFoundException, ChecksumException, FormatException;
+  Result decode(AbstractBinaryBitmap image) throws NotFoundException, ChecksumException, FormatException;
 
   /**
    * Locates and decodes a barcode in some format within an image. This method also accepts
@@ -57,7 +57,7 @@ public interface Reader {
    * @throws ChecksumException if a potential barcode is found but does not pass its checksum
    * @throws FormatException if a potential barcode is found but format is invalid
    */
-  Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints)
+  Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints)
       throws NotFoundException, ChecksumException, FormatException;
 
   /**

--- a/core/src/main/java/com/google/zxing/aztec/AztecReader.java
+++ b/core/src/main/java/com/google/zxing/aztec/AztecReader.java
@@ -17,7 +17,7 @@
 package com.google.zxing.aztec;
 
 import com.google.zxing.BarcodeFormat;
-import com.google.zxing.BinaryBitmap;
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.FormatException;
 import com.google.zxing.NotFoundException;
@@ -48,12 +48,12 @@ public final class AztecReader implements Reader {
    * @throws FormatException if a Data Matrix code cannot be decoded
    */
   @Override
-  public Result decode(BinaryBitmap image) throws NotFoundException, FormatException {
+  public Result decode(AbstractBinaryBitmap image) throws NotFoundException, FormatException {
     return decode(image, null);
   }
 
   @Override
-  public Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints)
+  public Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints)
       throws NotFoundException, FormatException {
 
     NotFoundException notFoundException = null;

--- a/core/src/main/java/com/google/zxing/datamatrix/DataMatrixReader.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/DataMatrixReader.java
@@ -17,7 +17,7 @@
 package com.google.zxing.datamatrix;
 
 import com.google.zxing.BarcodeFormat;
-import com.google.zxing.BinaryBitmap;
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.ChecksumException;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.FormatException;
@@ -55,12 +55,12 @@ public final class DataMatrixReader implements Reader {
    * @throws ChecksumException if error correction fails
    */
   @Override
-  public Result decode(BinaryBitmap image) throws NotFoundException, ChecksumException, FormatException {
+  public Result decode(AbstractBinaryBitmap image) throws NotFoundException, ChecksumException, FormatException {
     return decode(image, null);
   }
 
   @Override
-  public Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints)
+  public Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints)
       throws NotFoundException, ChecksumException, FormatException {
     DecoderResult decoderResult;
     ResultPoint[] points;

--- a/core/src/main/java/com/google/zxing/maxicode/MaxiCodeReader.java
+++ b/core/src/main/java/com/google/zxing/maxicode/MaxiCodeReader.java
@@ -17,7 +17,7 @@
 package com.google.zxing.maxicode;
 
 import com.google.zxing.BarcodeFormat;
-import com.google.zxing.BinaryBitmap;
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.ChecksumException;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.FormatException;
@@ -52,12 +52,12 @@ public final class MaxiCodeReader implements Reader {
    * @throws ChecksumException if error correction fails
    */
   @Override
-  public Result decode(BinaryBitmap image) throws NotFoundException, ChecksumException, FormatException {
+  public Result decode(AbstractBinaryBitmap image) throws NotFoundException, ChecksumException, FormatException {
     return decode(image, null);
   }
 
   @Override
-  public Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints)
+  public Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints)
       throws NotFoundException, ChecksumException, FormatException {
     // Note that MaxiCode reader effectively always assumes PURE_BARCODE mode
     // and can't detect it in an image

--- a/core/src/main/java/com/google/zxing/multi/ByQuadrantReader.java
+++ b/core/src/main/java/com/google/zxing/multi/ByQuadrantReader.java
@@ -16,7 +16,7 @@
 
 package com.google.zxing.multi;
 
-import com.google.zxing.BinaryBitmap;
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.ChecksumException;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.FormatException;
@@ -45,13 +45,13 @@ public final class ByQuadrantReader implements Reader {
   }
 
   @Override
-  public Result decode(BinaryBitmap image)
+  public Result decode(AbstractBinaryBitmap image)
       throws NotFoundException, ChecksumException, FormatException {
     return decode(image, null);
   }
 
   @Override
-  public Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints)
+  public Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints)
       throws NotFoundException, ChecksumException, FormatException {
 
     int width = image.getWidth();
@@ -92,7 +92,7 @@ public final class ByQuadrantReader implements Reader {
 
     int quarterWidth = halfWidth / 2;
     int quarterHeight = halfHeight / 2;
-    BinaryBitmap center = image.crop(quarterWidth, quarterHeight, halfWidth, halfHeight);
+    AbstractBinaryBitmap center = image.crop(quarterWidth, quarterHeight, halfWidth, halfHeight);
     Result result = delegate.decode(center, hints);
     makeAbsolute(result.getResultPoints(), quarterWidth, quarterHeight);
     return result;
@@ -109,7 +109,7 @@ public final class ByQuadrantReader implements Reader {
         ResultPoint relative = points[i];
         if (relative != null) {
           points[i] = new ResultPoint(relative.getX() + leftOffset, relative.getY() + topOffset);
-        }    
+        }
       }
     }
   }

--- a/core/src/main/java/com/google/zxing/multi/GenericMultipleBarcodeReader.java
+++ b/core/src/main/java/com/google/zxing/multi/GenericMultipleBarcodeReader.java
@@ -16,7 +16,7 @@
 
 package com.google.zxing.multi;
 
-import com.google.zxing.BinaryBitmap;
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.NotFoundException;
 import com.google.zxing.Reader;
@@ -56,12 +56,12 @@ public final class GenericMultipleBarcodeReader implements MultipleBarcodeReader
   }
 
   @Override
-  public Result[] decodeMultiple(BinaryBitmap image) throws NotFoundException {
+  public Result[] decodeMultiple(AbstractBinaryBitmap image) throws NotFoundException {
     return decodeMultiple(image, null);
   }
 
   @Override
-  public Result[] decodeMultiple(BinaryBitmap image, Map<DecodeHintType,?> hints)
+  public Result[] decodeMultiple(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints)
       throws NotFoundException {
     List<Result> results = new ArrayList<>();
     doDecodeMultiple(image, hints, results, 0, 0, 0);
@@ -71,7 +71,7 @@ public final class GenericMultipleBarcodeReader implements MultipleBarcodeReader
     return results.toArray(EMPTY_RESULT_ARRAY);
   }
 
-  private void doDecodeMultiple(BinaryBitmap image,
+  private void doDecodeMultiple(AbstractBinaryBitmap image,
                                 Map<DecodeHintType,?> hints,
                                 List<Result> results,
                                 int xOffset,

--- a/core/src/main/java/com/google/zxing/multi/MultipleBarcodeReader.java
+++ b/core/src/main/java/com/google/zxing/multi/MultipleBarcodeReader.java
@@ -16,7 +16,7 @@
 
 package com.google.zxing.multi;
 
-import com.google.zxing.BinaryBitmap;
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.NotFoundException;
 import com.google.zxing.Result;
@@ -31,9 +31,9 @@ import java.util.Map;
  */
 public interface MultipleBarcodeReader {
 
-  Result[] decodeMultiple(BinaryBitmap image) throws NotFoundException;
+  Result[] decodeMultiple(AbstractBinaryBitmap image) throws NotFoundException;
 
-  Result[] decodeMultiple(BinaryBitmap image,
+  Result[] decodeMultiple(AbstractBinaryBitmap image,
                           Map<DecodeHintType,?> hints) throws NotFoundException;
 
 }

--- a/core/src/main/java/com/google/zxing/multi/qrcode/QRCodeMultiReader.java
+++ b/core/src/main/java/com/google/zxing/multi/qrcode/QRCodeMultiReader.java
@@ -16,8 +16,8 @@
 
 package com.google.zxing.multi.qrcode;
 
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.BarcodeFormat;
-import com.google.zxing.BinaryBitmap;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.NotFoundException;
 import com.google.zxing.ReaderException;
@@ -51,12 +51,12 @@ public final class QRCodeMultiReader extends QRCodeReader implements MultipleBar
   private static final ResultPoint[] NO_POINTS = new ResultPoint[0];
 
   @Override
-  public Result[] decodeMultiple(BinaryBitmap image) throws NotFoundException {
+  public Result[] decodeMultiple(AbstractBinaryBitmap image) throws NotFoundException {
     return decodeMultiple(image, null);
   }
 
   @Override
-  public Result[] decodeMultiple(BinaryBitmap image, Map<DecodeHintType,?> hints) throws NotFoundException {
+  public Result[] decodeMultiple(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints) throws NotFoundException {
     List<Result> results = new ArrayList<>();
     DetectorResult[] detectorResults = new MultiDetector(image.getBlackMatrix()).detectMulti(hints);
     for (DetectorResult detectorResult : detectorResults) {

--- a/core/src/main/java/com/google/zxing/oned/OneDReader.java
+++ b/core/src/main/java/com/google/zxing/oned/OneDReader.java
@@ -16,7 +16,7 @@
 
 package com.google.zxing.oned;
 
-import com.google.zxing.BinaryBitmap;
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.ChecksumException;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.FormatException;
@@ -42,20 +42,20 @@ import java.util.Map;
 public abstract class OneDReader implements Reader {
 
   @Override
-  public Result decode(BinaryBitmap image) throws NotFoundException, FormatException {
+  public Result decode(AbstractBinaryBitmap image) throws NotFoundException, FormatException {
     return decode(image, null);
   }
 
   // Note that we don't try rotation without the try harder flag, even if rotation was supported.
   @Override
-  public Result decode(BinaryBitmap image,
+  public Result decode(AbstractBinaryBitmap image,
                        Map<DecodeHintType,?> hints) throws NotFoundException, FormatException {
     try {
       return doDecode(image, hints);
     } catch (NotFoundException nfe) {
       boolean tryHarder = hints != null && hints.containsKey(DecodeHintType.TRY_HARDER);
-      if (tryHarder && image.isRotateSupported()) {
-        BinaryBitmap rotatedImage = image.rotateCounterClockwise();
+      if (tryHarder && image.isRotate90Supported()) {
+        AbstractBinaryBitmap rotatedImage = image.rotateCounterClockwise();
         Result result = doDecode(rotatedImage, hints);
         // Record that we found it rotated 90 degrees CCW / 270 degrees CW
         Map<ResultMetadataType,?> metadata = result.getResultMetadata();
@@ -100,7 +100,7 @@ public abstract class OneDReader implements Reader {
    * @return The contents of the decoded barcode
    * @throws NotFoundException Any spontaneous errors which occur
    */
-  private Result doDecode(BinaryBitmap image,
+  private Result doDecode(AbstractBinaryBitmap image,
                           Map<DecodeHintType,?> hints) throws NotFoundException {
     int width = image.getWidth();
     int height = image.getHeight();

--- a/core/src/main/java/com/google/zxing/oned/UPCAReader.java
+++ b/core/src/main/java/com/google/zxing/oned/UPCAReader.java
@@ -16,8 +16,8 @@
 
 package com.google.zxing.oned;
 
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.BarcodeFormat;
-import com.google.zxing.BinaryBitmap;
 import com.google.zxing.ChecksumException;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.FormatException;
@@ -53,12 +53,12 @@ public final class UPCAReader extends UPCEANReader {
   }
 
   @Override
-  public Result decode(BinaryBitmap image) throws NotFoundException, FormatException {
+  public Result decode(AbstractBinaryBitmap image) throws NotFoundException, FormatException {
     return maybeReturnResult(ean13Reader.decode(image));
   }
 
   @Override
-  public Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints)
+  public Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints)
       throws NotFoundException, FormatException {
     return maybeReturnResult(ean13Reader.decode(image, hints));
   }

--- a/core/src/main/java/com/google/zxing/pdf417/PDF417Reader.java
+++ b/core/src/main/java/com/google/zxing/pdf417/PDF417Reader.java
@@ -16,8 +16,8 @@
 
 package com.google.zxing.pdf417;
 
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.BarcodeFormat;
-import com.google.zxing.BinaryBitmap;
 import com.google.zxing.ChecksumException;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.FormatException;
@@ -53,12 +53,12 @@ public final class PDF417Reader implements Reader, MultipleBarcodeReader {
    * @throws FormatException if a PDF417 cannot be decoded
    */
   @Override
-  public Result decode(BinaryBitmap image) throws NotFoundException, FormatException, ChecksumException {
+  public Result decode(AbstractBinaryBitmap image) throws NotFoundException, FormatException, ChecksumException {
     return decode(image, null);
   }
 
   @Override
-  public Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints) throws NotFoundException, FormatException,
+  public Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints) throws NotFoundException, FormatException,
       ChecksumException {
     Result[] result = decode(image, hints, false);
     if (result.length == 0 || result[0] == null) {
@@ -68,12 +68,12 @@ public final class PDF417Reader implements Reader, MultipleBarcodeReader {
   }
 
   @Override
-  public Result[] decodeMultiple(BinaryBitmap image) throws NotFoundException {
+  public Result[] decodeMultiple(AbstractBinaryBitmap image) throws NotFoundException {
     return decodeMultiple(image, null);
   }
 
   @Override
-  public Result[] decodeMultiple(BinaryBitmap image, Map<DecodeHintType,?> hints) throws NotFoundException {
+  public Result[] decodeMultiple(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints) throws NotFoundException {
     try {
       return decode(image, hints, true);
     } catch (FormatException | ChecksumException ignored) {
@@ -81,7 +81,7 @@ public final class PDF417Reader implements Reader, MultipleBarcodeReader {
     }
   }
 
-  private static Result[] decode(BinaryBitmap image, Map<DecodeHintType, ?> hints, boolean multiple)
+  private static Result[] decode(AbstractBinaryBitmap image, Map<DecodeHintType, ?> hints, boolean multiple)
       throws NotFoundException, FormatException, ChecksumException {
     List<Result> results = new ArrayList<>();
     PDF417DetectorResult detectorResult = Detector.detect(image, hints, multiple);

--- a/core/src/main/java/com/google/zxing/pdf417/detector/Detector.java
+++ b/core/src/main/java/com/google/zxing/pdf417/detector/Detector.java
@@ -16,7 +16,7 @@
 
 package com.google.zxing.pdf417.detector;
 
-import com.google.zxing.BinaryBitmap;
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.NotFoundException;
 import com.google.zxing.ResultPoint;
@@ -70,7 +70,7 @@ public final class Detector {
    * @return {@link PDF417DetectorResult} encapsulating results of detecting a PDF417 code
    * @throws NotFoundException if no PDF417 Code can be found
    */
-  public static PDF417DetectorResult detect(BinaryBitmap image, Map<DecodeHintType,?> hints, boolean multiple)
+  public static PDF417DetectorResult detect(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints, boolean multiple)
       throws NotFoundException {
     // TODO detection improvement, tryHarder could try several different luminance thresholds/blackpoints or even
     // different binarizers

--- a/core/src/main/java/com/google/zxing/qrcode/QRCodeReader.java
+++ b/core/src/main/java/com/google/zxing/qrcode/QRCodeReader.java
@@ -16,8 +16,8 @@
 
 package com.google.zxing.qrcode;
 
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.BarcodeFormat;
-import com.google.zxing.BinaryBitmap;
 import com.google.zxing.ChecksumException;
 import com.google.zxing.DecodeHintType;
 import com.google.zxing.FormatException;
@@ -60,12 +60,12 @@ public class QRCodeReader implements Reader {
    * @throws ChecksumException if error correction fails
    */
   @Override
-  public Result decode(BinaryBitmap image) throws NotFoundException, ChecksumException, FormatException {
+  public Result decode(AbstractBinaryBitmap image) throws NotFoundException, ChecksumException, FormatException {
     return decode(image, null);
   }
 
   @Override
-  public final Result decode(BinaryBitmap image, Map<DecodeHintType,?> hints)
+  public final Result decode(AbstractBinaryBitmap image, Map<DecodeHintType,?> hints)
       throws NotFoundException, ChecksumException, FormatException {
     DecoderResult decoderResult;
     ResultPoint[] points;

--- a/core/src/test/java/com/google/zxing/common/AbstractBlackBoxTestCase.java
+++ b/core/src/test/java/com/google/zxing/common/AbstractBlackBoxTestCase.java
@@ -16,6 +16,7 @@
 
 package com.google.zxing.common;
 
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.BinaryBitmap;
 import com.google.zxing.BufferedImageLuminanceSource;
@@ -249,7 +250,7 @@ public abstract class AbstractBlackBoxTestCase extends Assert {
     }
   }
 
-  private boolean decode(BinaryBitmap source,
+  private boolean decode(AbstractBinaryBitmap source,
                          float rotation,
                          String expectedText,
                          Map<?,?> expectedMetadata,

--- a/core/src/test/java/com/google/zxing/pdf417/PDF417BlackBox4TestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/PDF417BlackBox4TestCase.java
@@ -16,6 +16,7 @@
 
 package com.google.zxing.pdf417;
 
+import com.google.zxing.AbstractBinaryBitmap;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.BinaryBitmap;
 import com.google.zxing.BufferedImageLuminanceSource;
@@ -166,7 +167,7 @@ public final class PDF417BlackBox4TestCase extends AbstractBlackBoxTestCase {
         ResultMetadataType.PDF417_EXTRA_METADATA);
   }
 
-  private Result[] decode(BinaryBitmap source, boolean tryHarder) throws ReaderException {
+  private Result[] decode(AbstractBinaryBitmap source, boolean tryHarder) throws ReaderException {
     Map<DecodeHintType,Object> hints = new EnumMap<>(DecodeHintType.class);
     if (tryHarder) {
       hints.put(DecodeHintType.TRY_HARDER, Boolean.TRUE);


### PR DESCRIPTION
This change should help with custom BinaryBitmap implementations, which are now awkward to create.
This way was chosen instead of making the BinaryBitmap into an interface to minimize breakage
for end users, as I assume that there are more people using BinaryBitmap than implementing custom Readers.
Making the BinaryBitmap non-final is also an option, but custom subclasses would be fragile with regards
to future BinaryBitmap changes.

This also splits isRotateSupported into two variants, for 90 and 45 degrees, to make it easier to implement
rotation support properly, given that 45 degree rotation is not used by built-in Readers, but is required
to leverage the rotation support.

*This contribution is my original work and I license the work to the project under the project's open source license.*