### PR TITLE
small fix: valid `y` range

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/detector/Detector.java
+++ b/core/src/main/java/com/google/zxing/aztec/detector/Detector.java
@@ -550,7 +550,7 @@ public final class Detector {
   }
 
   private boolean isValid(int x, int y) {
-    return x >= 0 && x < image.getWidth() && y > 0 && y < image.getHeight();
+    return x >= 0 && x < image.getWidth() && y >= 0 && y < image.getHeight();
   }
 
   private boolean isValid(ResultPoint point) {


### PR DESCRIPTION
`y = 0` is valid like `x`.