### PR TITLE
Fix decoding of FNC1 in AztecCode.

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -153,30 +153,20 @@ public final class Decoder {
           }
           int n = readCode(correctedBits, index, 3);
           index += 3;
+          //  flush bytes, FLG changes state
+          try {
+            result.append(decodedBytes.toString(encoding.name()));
+          } catch (UnsupportedEncodingException uee) {
+            throw new IllegalStateException(uee);
+          }
+          decodedBytes.reset();
           switch (n) {
             case 0:
-              //  flush bytes before outputting FNC1
-              try {
-                  result.append(decodedBytes.toString(encoding.name()));
-              } catch (UnsupportedEncodingException uee) {
-                  throw new IllegalStateException(uee);
-              }
-              decodedBytes.reset();
-
               result.append((char) 29);  // translate FNC1 as ASCII 29
               break;
             case 7:
               throw FormatException.getFormatInstance(); // FLG(7) is reserved and illegal
             default:
-              // flush bytes before changing character set
-              try {
-                result.append(decodedBytes.toString(encoding.name()));
-              } catch (UnsupportedEncodingException uee) {
-                // can't happen
-                throw new IllegalStateException(uee);
-              }
-              decodedBytes.reset();
-
               // ECI is decimal integer encoded as 1-6 codes in DIGIT mode
               int eci = 0;
               if (endIndex - index < 4 * n) {

--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -155,6 +155,14 @@ public final class Decoder {
           index += 3;
           switch (n) {
             case 0:
+              //  flush bytes before outputting FNC1
+              try {
+                  result.append(decodedBytes.toString(encoding.name()));
+              } catch (UnsupportedEncodingException uee) {
+                  throw new IllegalStateException(uee);
+              }
+              decodedBytes.reset();
+
               result.append((char) 29);  // translate FNC1 as ASCII 29
               break;
             case 7:

--- a/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
@@ -50,6 +50,11 @@ public final class DecoderTest extends Assert {
       testHighLevelDecodeString("±Ça",
          // B/S 1     0xb1     P/S   FLG(n) 2  '2'  '6'  B/S   2     0xc3     0x87     L/L   'a'
          "XXXXX ....X X.XX...X ..... ..... .X. .X.. X... XXXXX ...X. XX....XX X....XXX XXX.. ...X.");
+
+      // GS1 data
+      testHighLevelDecodeString("101233742",
+         // P/S FLG(n) 0  D/L   1    0    1    2    3    P/S  FLG(n) 0  3    7    4    2
+         "..... ..... ... XXXX. ..XX ..X. ..XX .X.. .X.X .... ..... ... .X.X X..X .XX. .X..");
   }
 
   private static void testHighLevelDecodeString(String expectedString, String b) throws FormatException {


### PR DESCRIPTION
I discovered that when decoding an Aztec GS1 barcode, all <GS> characters are output at the beginning of the stream. This patch fixes that.