### PR TITLE
Add option to output raw bitstream from CommandLineRunner.

### DIFF
--- a/javase/src/main/java/com/google/zxing/client/j2se/DecodeWorker.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/DecodeWorker.java
@@ -165,6 +165,17 @@ final class DecodeWorker implements Callable<Integer> {
             result.getText() + "\n" +
             "Parsed result:\n" +
             parsedResult.getDisplayResult() + "\n");
+
+        if (config.outputRaw) {
+            String rawData = "";
+
+            for (byte b : result.getRawBytes()) {
+                rawData = rawData + String.format("%02X", b & 0xff) + ' ';
+            }
+
+            output.write("Raw bits:\n" + rawData + "\n");
+        }
+
         ResultPoint[] resultPoints = result.getResultPoints();
         int numResultPoints = resultPoints.length;
         output.write("Found " + numResultPoints + " result points.\n");

--- a/javase/src/main/java/com/google/zxing/client/j2se/DecodeWorker.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/DecodeWorker.java
@@ -167,13 +167,15 @@ final class DecodeWorker implements Callable<Integer> {
             parsedResult.getDisplayResult() + "\n");
 
         if (config.outputRaw) {
-            String rawData = "";
+          StringBuilder rawData = new StringBuilder();
 
-            for (byte b : result.getRawBytes()) {
-                rawData = rawData + String.format("%02X", b & 0xff) + ' ';
-            }
+          for (byte b : result.getRawBytes()) {
+            rawData.append(String.format("%02X", b & 0xff));
+            rawData.append(" ");
+          }
+          rawData.setLength(rawData.length() - 1);  // chop off final space
 
-            output.write("Raw bits:\n" + rawData + "\n");
+          output.write("Raw bits:\n" + rawData.toString() + "\n");
         }
 
         ResultPoint[] resultPoints = result.getResultPoints();

--- a/javase/src/main/java/com/google/zxing/client/j2se/DecoderConfig.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/DecoderConfig.java
@@ -58,6 +58,10 @@ final class DecoderConfig {
       description = "Only output one line per file, omitting the contents")
   boolean brief;
 
+  @Parameter(names = "--raw",
+      description = "Output raw bitstream, before decoding symbols")
+  boolean outputRaw;
+
   @Parameter(names = "--recursive",
       description = "Descend into subdirectories")
   boolean recursive;


### PR DESCRIPTION
A small patch to add a --raw option to the CommandLineRunner to get the raw bitstream from the decode of the barcode. This is useful, especially when debugging encoding issues in barcode encoders. The same data is available in the web decoder, but sometimes the command line is easier.