### PR TITLE
Change sort method to work with any android api

### DIFF
--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -25,6 +25,7 @@ import com.google.zxing.common.BitMatrix;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -621,7 +622,7 @@ public class FinderPatternFinder {
       throw NotFoundException.getNotFoundInstance();
     }
 
-    possibleCenters.sort(moduleComparator);
+    Collections.sort(possibleCenters, moduleComparator);
 
     double distortion = Double.MAX_VALUE;
     FinderPattern[] bestPatterns = new FinderPattern[3];


### PR DESCRIPTION
List.sort(Comparator) only work with android API >= N
So I change it to Collections.sort(List, Comparator)