### PR TITLE
Fix of glitch in specification ISO/IEC 16022 Second edition Annex P as…

### DIFF
--- a/core/src/main/java/com/google/zxing/datamatrix/encoder/HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/encoder/HighLevelEncoder.java
@@ -193,6 +193,26 @@ public final class HighLevelEncoder {
   }
 
   static int lookAheadTest(CharSequence msg, int startpos, int currentMode) {
+    int newMode = lookAheadTestIntern(msg, startpos, currentMode);
+    if (currentMode == X12_ENCODATION && newMode == X12_ENCODATION) {
+      int endpos = Math.min(startpos + 3, msg.length());
+      for (int i = startpos; i < endpos; i++) {
+        if (!isNativeX12(msg.charAt(i))) {
+          return ASCII_ENCODATION;
+        }
+      }
+    } else if (currentMode == EDIFACT_ENCODATION && newMode == EDIFACT_ENCODATION) {
+      int endpos = Math.min(startpos + 4, msg.length());
+      for (int i = startpos; i < endpos; i++) {
+        if (!isNativeEDIFACT(msg.charAt(i))) {
+          return ASCII_ENCODATION;
+        }
+      }
+    }
+    return newMode;
+  }
+
+  static int lookAheadTestIntern(CharSequence msg, int startpos, int currentMode) {
     if (startpos >= msg.length()) {
       return currentMode;
     }

--- a/core/src/test/java/com/google/zxing/datamatrix/encoder/HighLevelEncodeTestCase.java
+++ b/core/src/test/java/com/google/zxing/datamatrix/encoder/HighLevelEncodeTestCase.java
@@ -353,6 +353,33 @@ public final class HighLevelEncodeTestCase extends Assert {
     assertEquals("240 168 209 77 4 229 45 196 107 77 21 53 5 12 135 192", visualized);
   }
 
+  @Test
+  public void testX12AndEDIFACTSpecErrors() {
+    //X12 encoding error with spec conform float point comparisons in lookAheadTest()
+    String visualized = encodeHighLevel("AAAAAAAAAAA**\u00FCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    assertEquals("230 89 191 89 191 89 191 89 178 56 114 10 243 177 63 89 191 89 191 89 191 89 191 89 191 89 191 89 " +
+        "191 89 191 89 191 254 66 129", visualized);
+    //X12 encoding error with integer comparisons in lookAheadTest()
+    visualized = encodeHighLevel("AAAAAAAAAAAA0+****AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    assertEquals("238 89 191 89 191 89 191 89 191 254 240 194 186 170 170 160 65 4 16 65 4 16 65 4 16 65 4 16 65 4 " +
+        "16 65 4 16 65 4 16 65 124 129 167 62 212 107", visualized);
+    //EDIFACT encoding error with spec conform float point comparisons in lookAheadTest()
+    visualized = encodeHighLevel("AAAAAAAAAAA++++\u00FCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    assertEquals("230 89 191 89 191 89 191 254 66 66 44 44 44 44 235 125 230 89 191 89 191 89 191 89 191 89 191 89 " +
+        "191 89 191 89 191 89 191 89 191 254 129 17 167 62 212 107", visualized);
+    //EDIFACT encoding error with integer comparisons in lookAheadTest()
+    visualized = encodeHighLevel("++++++++++AAa0 0++++++++++++++++++++++++++++++");
+    assertEquals("240 174 186 235 174 186 235 174 176 65 124 98 240 194 12 43 174 186 235 174 186 235 174 186 235 " +
+        "174 186 235 174 186 235 174 186 235 174 186 235 173 240 129 167 62 212 107", visualized);
+    visualized = encodeHighLevel("AAAAAAAAAAAA*+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    assertEquals("230 89 191 89 191 89 191 89 191 7 170 64 191 89 191 89 191 89 191 89 191 89 191 89 191 89 191 89 " +
+        "191 89 191 66", visualized);
+    visualized = encodeHighLevel("AAAAAAAAAAA*0a0 *AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    assertEquals("230 89 191 89 191 89 191 89 178 56 227 6 228 7 183 89 191 89 191 89 191 89 191 89 191 89 191 89 " +
+        "191 89 191 89 191 254 66 66", visualized);
+
+  }
+
   private static String encodeHighLevel(String msg) {
     CharSequence encoded = HighLevelEncoder.encodeHighLevel(msg);
     //DecodeHighLevel.decode(encoded);


### PR DESCRIPTION
… suggested by Martin Burke of zint (See https://sourceforge.net/p/zint/code/ci/68566fefd2a4623041b0232a5941f8fed1e22018/)

Quote of Martin's proposed changes to the spec:
```quote
The algorithm can be salvaged to be at least sound by making those changes, e.g. by adding to step e):

 "1) If the next character cannot be encoded as X12, switch to ASCII mode and go to step b)."

(and renumbering the following sub-steps). Similarly step f):

"1) If the next character cannot be encoded as EDIFACT, switch to ASCII mode and go to step b)."
```
The program below finds about 75.000 failure patterns on the version before commit 97cb6ab, 35.000 patterns after the fix and no errors of course after this fix.
```java
import com.google.zxing.datamatrix.encoder.HighLevelEncoder;
import java.util.HashMap;

public class DataMatrixBug {
  final static char[] testChars={252,123,97,65,48,43,42,32,13};

  public static void main(String[] args) throws Exception {
    if(args.length == 0) {
      performBruteForceTest();
    } else {
      for (int i = 0; i< args.length; i++) {
        test(parseUnicodeEscapes(args[i]));
      }
    }
  }
  static void performBruteForceTest() throws Exception {
//for all character classes (one character from each class). The prefix and the postfix are strings made up solely from this character.
    for (int i = 0; i < testChars.length; i++) {
//vary prefix length between 10 and 13 so that a starting point of a new double or triple symbol character is hit
      for (int j = 0; j < 4; j++) {
//vary the length of the permuted middle part between 3 and 6
        for (int k = 0; k < 4; k++) {
//use a long postix to avoid running into "step k) end of data"
            performPermutationTest(getN(testChars[i],10+j),3+k,getN(testChars[i],30));
        }
      }
    }
  }
  static String getN(int c,int n) {
    String result="";
    while (n-->0) {
      result+=(char)c;
    }
    return result;
  }
  static void performPermutationTest(String prefix,int permuteLength,String postfix) throws Exception {
    int endIndex=getEndIndex(permuteLength);
    for (int i = 0; i <= endIndex; i++) {
      String input = prefix+generatePermutation(i, permuteLength)+postfix;
      try {
        test(input);
      }
      catch (Exception e) {
          System.err.println("ERROR: failed to encode \"" + input + "\" (error=" + e.getMessage() + ")");
      }
    }
  }
  static int getEndIndex(int length) {
//decimalLength = length log(9) / log(10) = 0.96 length
    return (int) Math.pow(10,0.96 * length);
  }
  static String generatePermutation(int index, int length) {
    String base9number=Integer.toString(index,9);
    while(base9number.length() < length) {
      base9number = "0"+base9number;
    }
    String prefix="";
    for (int i = 0; i < base9number.length(); i++) {
      prefix+=testChars[base9number.charAt(i)-'0'];
    }
    return prefix;
  }
  static void test(String input) throws Exception {
    String chars = HighLevelEncoder.encodeHighLevel(input);
    byte[] bytes = new byte[chars.length()];
    for (int i = 0; i < chars.length(); i++) {
        bytes[i] = (byte)(((int) chars.charAt(i)) & 0xFF);
    }
  }
  static String parseUnicodeEscapes(String s) {
      String result = "";
      for (int i = 0; i < s.length(); i++) {
          if (i + 5 < s.length() && s.charAt(i) == '\\' && s.charAt(i + 1) == 'u') {
              result += (char) Integer.parseInt(s.substring(i + 2,i + 2 + 4),16);
              i += 5;
          } else {
              result += s.charAt(i);
          }
      }
      return result;
  }
}

```