### PR TITLE
Fix for IllegalArgumentException encoding data-matrix with EncodeHintType.DATA_MATRIX_COMPACT

### DIFF
--- a/core/src/main/java/com/google/zxing/datamatrix/encoder/MinimalEncoder.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/encoder/MinimalEncoder.java
@@ -1019,6 +1019,15 @@ public final class MinimalEncoder {
         applyRandomPattern(bytesAL,bytesAL.size() - randomizePostfixLength.get(i).intValue(), 
             randomizeLengths.get(i).intValue());
       }
+      //add padding
+      int capacity = solution.getMinSymbolSize(bytesAL.size());
+      if (bytesAL.size() < capacity) {
+        bytesAL.add((byte) 129);
+      }
+      while (bytesAL.size() < capacity) {
+        bytesAL.add((byte) randomize253State(bytesAL.size() + 1));
+      }
+
       bytes = new byte[bytesAL.size()];
       for (int i = 0; i < bytes.length; i++) {
         bytes[i] = bytesAL.get(i).byteValue();
@@ -1030,6 +1039,12 @@ public final class MinimalEncoder {
         into.add(0, Byte.valueOf(bytes[i]));
       }
       return bytes.length;
+    }
+
+    private static int randomize253State(int codewordPosition) {
+      int pseudoRandom = ((149 * codewordPosition) % 253) + 1;
+      int tempVariable = 129 + pseudoRandom;
+      return tempVariable <= 254 ? tempVariable : tempVariable - 254;
     }
 
     static void applyRandomPattern(List<Byte> bytesAL,int startPosition, int length) {

--- a/core/src/test/java/com/google/zxing/datamatrix/encoder/HighLevelEncodeTestCase.java
+++ b/core/src/test/java/com/google/zxing/datamatrix/encoder/HighLevelEncodeTestCase.java
@@ -385,11 +385,11 @@ public final class HighLevelEncodeTestCase extends Assert {
     int[] sizes = new int[2];
     encodeHighLevel("A", sizes);
     assertEquals(3, sizes[0]);
-    assertEquals(1, sizes[1]);
+    assertEquals(3, sizes[1]);
 
     encodeHighLevel("AB", sizes);
     assertEquals(3, sizes[0]);
-    assertEquals(2, sizes[1]);
+    assertEquals(3, sizes[1]);
 
     encodeHighLevel("ABC", sizes);
     assertEquals(3, sizes[0]);
@@ -397,7 +397,7 @@ public final class HighLevelEncodeTestCase extends Assert {
 
     encodeHighLevel("ABCD", sizes);
     assertEquals(5, sizes[0]);
-    assertEquals(4, sizes[1]);
+    assertEquals(5, sizes[1]);
 
     encodeHighLevel("ABCDE", sizes);
     assertEquals(5, sizes[0]);
@@ -409,11 +409,11 @@ public final class HighLevelEncodeTestCase extends Assert {
 
     encodeHighLevel("ABCDEFG", sizes);
     assertEquals(8, sizes[0]);
-    assertEquals(7, sizes[1]);
+    assertEquals(8, sizes[1]);
 
     encodeHighLevel("ABCDEFGH", sizes);
     assertEquals(8, sizes[0]);
-    assertEquals(7, sizes[1]);
+    assertEquals(8, sizes[1]);
 
     encodeHighLevel("ABCDEFGHI", sizes);
     assertEquals(8, sizes[0]);
@@ -425,11 +425,11 @@ public final class HighLevelEncodeTestCase extends Assert {
 
     encodeHighLevel("a", sizes);
     assertEquals(3, sizes[0]);
-    assertEquals(1, sizes[1]);
+    assertEquals(3, sizes[1]);
 
     encodeHighLevel("ab", sizes);
     assertEquals(3, sizes[0]);
-    assertEquals(2, sizes[1]);
+    assertEquals(3, sizes[1]);
 
     encodeHighLevel("abc", sizes);
     assertEquals(3, sizes[0]);
@@ -437,7 +437,7 @@ public final class HighLevelEncodeTestCase extends Assert {
 
     encodeHighLevel("abcd", sizes);
     assertEquals(5, sizes[0]);
-    assertEquals(4, sizes[1]);
+    assertEquals(5, sizes[1]);
 
     encodeHighLevel("abcdef", sizes);
     assertEquals(5, sizes[0]);
@@ -445,7 +445,7 @@ public final class HighLevelEncodeTestCase extends Assert {
 
     encodeHighLevel("abcdefg", sizes);
     assertEquals(8, sizes[0]);
-    assertEquals(7, sizes[1]);
+    assertEquals(8, sizes[1]);
 
     encodeHighLevel("abcdefgh", sizes);
     assertEquals(8, sizes[0]);
@@ -453,11 +453,11 @@ public final class HighLevelEncodeTestCase extends Assert {
 
     encodeHighLevel("+", sizes);
     assertEquals(3, sizes[0]);
-    assertEquals(1, sizes[1]);
+    assertEquals(3, sizes[1]);
 
     encodeHighLevel("++", sizes);
     assertEquals(3, sizes[0]);
-    assertEquals(2, sizes[1]);
+    assertEquals(3, sizes[1]);
 
     encodeHighLevel("+++", sizes);
     assertEquals(3, sizes[0]);
@@ -465,7 +465,7 @@ public final class HighLevelEncodeTestCase extends Assert {
 
     encodeHighLevel("++++", sizes);
     assertEquals(5, sizes[0]);
-    assertEquals(4, sizes[1]);
+    assertEquals(5, sizes[1]);
 
     encodeHighLevel("+++++", sizes);
     assertEquals(5, sizes[0]);
@@ -473,15 +473,15 @@ public final class HighLevelEncodeTestCase extends Assert {
 
     encodeHighLevel("++++++", sizes);
     assertEquals(8, sizes[0]);
-    assertEquals(6, sizes[1]);
+    assertEquals(8, sizes[1]);
 
     encodeHighLevel("+++++++", sizes);
     assertEquals(8, sizes[0]);
-    assertEquals(7, sizes[1]);
+    assertEquals(8, sizes[1]);
 
     encodeHighLevel("++++++++", sizes);
     assertEquals(8, sizes[0]);
-    assertEquals(7, sizes[1]);
+    assertEquals(8, sizes[1]);
 
     encodeHighLevel("+++++++++", sizes);
     assertEquals(8, sizes[0]);
@@ -502,7 +502,8 @@ public final class HighLevelEncodeTestCase extends Assert {
     assertEquals("239 209 151 206 214 92 122 140 35 158 144 162 52 205 55 171 137 23 67 206 218 175 147 113 15 254" +
         " 116 33 241 25 231 186 14 212 64 253 151 252 159 33 41 241 27 231 83 171 53 209 35 25 134 6 42 33 35 239 184" +
         " 31 193 234 7 252 205 101 127 241 209 34 24 5 22 23 221 148 179 239 128 140 92 187 106 204 198 59 19 25 114" +
-        " 248 118 36 254 231 106 196 19 239 101 27 107 69 189 112 236 156 252 16 174 125 24 10 125 116 42", visualized);
+        " 248 118 36 254 231 106 196 19 239 101 27 107 69 189 112 236 156 252 16 174 125 24 10 125 116 42 129",
+        visualized);
 
     visualized = visualize(MinimalEncoder.encodeHighLevel("that particularly stands out to me is \u0625\u0650" +
         "\u062C\u064E\u0651\u0627\u0635 (\u02BE\u0101\u1E63) \"pear\", suggested to have originated from Hebrew " +
@@ -511,8 +512,19 @@ public final class HighLevelEncodeTestCase extends Assert {
         " 15 254 116 33 231 202 33 131 77 154 119 225 163 238 206 28 249 93 36 150 151 53 108 246 145 228 217 71" +
         " 199 42 33 35 239 184 31 193 234 7 252 205 101 127 241 209 34 24 5 22 23 221 148 179 239 128 140 92 187 106" +
         " 204 198 59 19 25 114 248 118 36 254 231 43 133 212 175 38 220 44 6 125 49 172 93 189 209 111 61 217 203 62" +
-        " 116 42", visualized);
+        " 116 42 129 1 151 46 196 91 241 137 32 182 77 227 122 18 168 63 213 108 4 154 49 199 94 244 140 35 185 80",
+         visualized);
   }
+
+  @Test
+  public void testPadding() {
+    int[] sizes = new int[2];
+    encodeHighLevel("IS010000000000000000000000S1118058599124123S21.2.250.1.213.1.4.8 S3FIRST NAMETEST S5MS618-06" +
+        "-1985S713201S4LASTNAMETEST", sizes);
+    assertEquals(86, sizes[0]);
+    assertEquals(86, sizes[1]);
+  }
+
 
   private static void encodeHighLevel(String msg, int[] sizes) {
     sizes[0] = HighLevelEncoder.encodeHighLevel(msg).length();


### PR DESCRIPTION
Fix for:
Exception in thread "main" java.lang.IllegalArgumentException: The number of codewords does not match the selected symbol
	at com.google.zxing.datamatrix.encoder.ErrorCorrection.encodeECC200(ErrorCorrection.java:103)
	at com.google.zxing.datamatrix.DataMatrixWriter.encode(DataMatrixWriter.java:112)