### PR TITLE
Add decoding hint DecodeHintType.QR_ASSUME_SPEC_CONFORM_INPUT

### DIFF
--- a/core/src/main/java/com/google/zxing/DecodeHintType.java
+++ b/core/src/main/java/com/google/zxing/DecodeHintType.java
@@ -104,6 +104,17 @@ public enum DecodeHintType {
    */
   ALSO_INVERTED(Void.class),
 
+  /**
+   * Specifies that the codes are expected to be in conformance with the specification
+   * ISO/IEC 18004 regading the interpretation of character encoding. Values encoded in BYTE mode
+   * or in KANJI mode are interpreted as ISO-8859-1 characters unless an ECI specified at a prior
+   * location in the input specified a different encoding. By default the encoding of BYTE encoded
+   * values is determinied by the {@link #CHARACTER_SET} hint or otherwise by a heuristic that
+   * examines the bytes. By default KANJI encoded values are interpreted as the bytes of Shift-JIS
+   * encoded characters.
+   */
+  QR_ASSUME_SPEC_CONFORM_INPUT(Void.class),
+
   // End of enumeration values.
   ;
 

--- a/core/src/main/java/com/google/zxing/DecodeHintType.java
+++ b/core/src/main/java/com/google/zxing/DecodeHintType.java
@@ -111,7 +111,7 @@ public enum DecodeHintType {
    * location in the input specified a different encoding. By default the encoding of BYTE encoded
    * values is determinied by the {@link #CHARACTER_SET} hint or otherwise by a heuristic that
    * examines the bytes. By default KANJI encoded values are interpreted as the bytes of Shift-JIS
-   * encoded characters (note that this is the case event if and ECI specifies a different
+   * encoded characters (note that this is the case even if an ECI specifies a different
    * encoding).
    */
   QR_ASSUME_SPEC_CONFORM_INPUT(Void.class),

--- a/core/src/main/java/com/google/zxing/DecodeHintType.java
+++ b/core/src/main/java/com/google/zxing/DecodeHintType.java
@@ -111,7 +111,8 @@ public enum DecodeHintType {
    * location in the input specified a different encoding. By default the encoding of BYTE encoded
    * values is determinied by the {@link #CHARACTER_SET} hint or otherwise by a heuristic that
    * examines the bytes. By default KANJI encoded values are interpreted as the bytes of Shift-JIS
-   * encoded characters.
+   * encoded characters (note that this is the case event if and ECI specifies a different
+   * encoding).
    */
   QR_ASSUME_SPEC_CONFORM_INPUT(Void.class),
 

--- a/core/src/main/java/com/google/zxing/common/StringUtils.java
+++ b/core/src/main/java/com/google/zxing/common/StringUtils.java
@@ -33,7 +33,6 @@ public final class StringUtils {
   private static final Charset PLATFORM_DEFAULT_ENCODING = Charset.defaultCharset();
   public static final Charset SHIFT_JIS_CHARSET = Charset.forName("SJIS");
   public static final Charset GB2312_CHARSET = Charset.forName("GB2312");
-  public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
   private static final Charset EUC_JP = Charset.forName("EUC_JP");
   private static final boolean ASSUME_SHIFT_JIS =
       SHIFT_JIS_CHARSET.equals(PLATFORM_DEFAULT_ENCODING) ||

--- a/core/src/main/java/com/google/zxing/common/StringUtils.java
+++ b/core/src/main/java/com/google/zxing/common/StringUtils.java
@@ -33,6 +33,7 @@ public final class StringUtils {
   private static final Charset PLATFORM_DEFAULT_ENCODING = Charset.defaultCharset();
   public static final Charset SHIFT_JIS_CHARSET = Charset.forName("SJIS");
   public static final Charset GB2312_CHARSET = Charset.forName("GB2312");
+  public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
   private static final Charset EUC_JP = Charset.forName("EUC_JP");
   private static final boolean ASSUME_SHIFT_JIS =
       SHIFT_JIS_CHARSET.equals(PLATFORM_DEFAULT_ENCODING) ||

--- a/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
@@ -235,8 +235,6 @@ final class DecodedBitStreamParser {
       count--;
     }
     Charset encoding;
-    // @Sean: This is the version that is 100% backward compatible
-    /*
     if (hints != null && hints.containsKey(DecodeHintType.QR_ASSUME_SPEC_CONFORM_INPUT)) {
       if (currentCharacterSetECI == null) {
         encoding = StringUtils.ISO_8859_1;
@@ -245,17 +243,6 @@ final class DecodedBitStreamParser {
       }
     } else {
       encoding = StringUtils.SHIFT_JIS_CHARSET;
-    }
-    */
-    // @Sean: This treats it the same way as BYTE mode in the sense that an ECI has priority
-    if (currentCharacterSetECI == null) {
-      if (hints != null && hints.containsKey(DecodeHintType.QR_ASSUME_SPEC_CONFORM_INPUT)) {
-        encoding = StringUtils.ISO_8859_1;
-      } else {
-        encoding = StringUtils.SHIFT_JIS_CHARSET;
-      }
-    } else {
-      encoding = currentCharacterSetECI.getCharset();
     }
     result.append(new String(buffer, encoding));
   }

--- a/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
@@ -24,6 +24,7 @@ import com.google.zxing.common.DecoderResult;
 import com.google.zxing.common.StringUtils;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -237,7 +238,7 @@ final class DecodedBitStreamParser {
     Charset encoding;
     if (hints != null && hints.containsKey(DecodeHintType.QR_ASSUME_SPEC_CONFORM_INPUT)) {
       if (currentCharacterSetECI == null) {
-        encoding = StringUtils.ISO_8859_1;
+        encoding = StandardCharsets.ISO_8859_1;
       } else {
         encoding = currentCharacterSetECI.getCharset();
       }
@@ -265,7 +266,7 @@ final class DecodedBitStreamParser {
     Charset encoding;
     if (currentCharacterSetECI == null) {
       if (hints != null && hints.containsKey(DecodeHintType.QR_ASSUME_SPEC_CONFORM_INPUT)) {
-        encoding = StringUtils.ISO_8859_1;
+        encoding = StandardCharsets.ISO_8859_1;
       } else {
         encoding = StringUtils.guessCharset(readBytes, hints);
       }

--- a/core/src/main/java/com/google/zxing/qrcode/encoder/MinimalEncoder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/encoder/MinimalEncoder.java
@@ -29,13 +29,9 @@ import java.util.List;
 
 
 /**
- * Encoder that encodes minimally
+ * Encoder that encodes minimally using Dijkstra
  *
- * Algorithm:
- *
- * The eleventh commandment was "Thou Shalt Compute" or "Thou Shalt Not Compute" - I forget which (Alan Perilis).
- *
- * This implementation computes. As an alternative, the QR-Code specification suggests heuristics like this one:
+ * The QR-Code specification suggests alternative heuristics like this one:
  *
  * If initial input data is in the exclusive subset of the Alphanumeric character set AND if there are less than
  * [6,7,8] characters followed by data from the remainder of the 8-bit byte character set, THEN select the 8-
@@ -52,6 +48,13 @@ import java.util.List;
  * ECI(UTF-8), BYTE(\u0150\u015C) while prepending one or more times the same leading character as in
  * "\u0150\u0150\u015C", the most compact representation uses two ECIs so that the string is encoded as
  * ECI(ISO-8859-2), BYTE(\u0150\u0150), ECI(ISO-8859-3), BYTE(\u015C).
+ *
+ * KANJI encoding: Currently this implementation will choose KANJI mode only if the input contains characters that can
+ * be encoded in Shift-JIS as double byte values.
+ * In other words, KANJI mode is never chosen for input that is composed from ISO-8859-1 characters. This avoids
+ * problems with the zxing decoder who by default assumes that KANJI encoded values represent the bytes of Shift-JIS
+ * encoded characters {@link com.google.zxing.DecodeHintType#QR_ASSUME_SPEC_CONFORM_INPUT}. This implies that ecoding
+ * binary data with this encoder may not be as compact as it would be if it would make use of the KANJI mode.
  *
  * @author Alex Geller
  */


### PR DESCRIPTION
Important: This also changes the default decoding behavior of the qr-code decoder for the case that  KANJI mode data is encountered which is preceded by an ECI with a value different than 20 (Shift-JIS). In this case the data in interpreted in the encoding of the ECI and not as Shift-JIS.