### PR TITLE
Share the ECI string builder of the data matrix decoder with the PDF417 decoder

### DIFF
--- a/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
+++ b/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 ZXing authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zxing.common;
+
+import com.google.zxing.FormatException;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Class that converts a sequence of ECIs and byte into a string to be used for decoding multi-eci content
+ *
+ * @author Alex Geller
+ */
+
+public final class ECIStringBuilder {
+  private StringBuilder currentBytes;
+  private StringBuilder result;
+  private Charset currentCharset = StandardCharsets.ISO_8859_1;
+
+  public ECIStringBuilder() {
+    currentBytes = new StringBuilder();
+  }
+  public ECIStringBuilder(int initialCapacity) {
+    currentBytes = new StringBuilder(initialCapacity);
+  }
+
+  public void append(char value) {
+    currentBytes.append((char) (value & 0xff));
+  }
+
+  public void append(byte value) {
+    currentBytes.append((char) (value & 0xff));
+  }
+
+  public void append(String value) {
+    currentBytes.append(value);
+  }
+
+  /* short for {@code append("" + value)}*/
+  public void append(int value) {
+    append("" + value);
+  }
+
+  public void appendECI(int value) throws FormatException {
+    encodeCurrentBytesIfAny();
+    CharacterSetECI characterSetECI = CharacterSetECI.getCharacterSetECIByValue(value);
+    if (characterSetECI == null) {
+      throw FormatException.getFormatInstance(new RuntimeException("Unsupported ECI value " + value));
+    }
+    currentCharset = characterSetECI.getCharset();
+  }
+
+  private void encodeCurrentBytesIfAny() {
+    if (currentCharset == StandardCharsets.ISO_8859_1) {
+      if (currentBytes.length() > 0) {
+        if (result == null) {
+          result = currentBytes;
+          currentBytes = new StringBuilder();
+        } else {
+          result.append(currentBytes);
+          currentBytes.setLength(0);
+        }
+      }
+    } else if (currentBytes.length() > 0) {
+      byte[] bytes = new byte[currentBytes.length()];
+      for (int i = 0; i < bytes.length; i++) {
+        bytes[i] = (byte) (currentBytes.charAt(i) & 0xff);
+      }
+      currentBytes.setLength(0);
+      if (result == null) {
+        result = new StringBuilder(new String(bytes, currentCharset));
+      } else {
+        result.append(new String(bytes, currentCharset));
+      }
+    }
+  }
+
+  /**
+   * appends the characters from sb (unlike all other append methods of this class who append bytes)
+   */
+  public void appendCharacters(StringBuilder value) {
+    encodeCurrentBytesIfAny();
+    result.append(value);
+  }
+
+  /**
+   * returns the length of toString()
+   */
+  public int length() {
+    return toString().length();
+  }
+
+  public boolean isEmpty() {
+    return currentBytes.length() == 0 && (result == null || result.length() == 0);
+  }
+
+  @Override
+  public String toString() {
+    encodeCurrentBytesIfAny();
+    return result == null ? "" : result.toString();
+  }
+}

--- a/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
+++ b/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
@@ -39,28 +39,28 @@ public final class ECIStringBuilder {
   }
 
   /**
-   * appends {@code value} as a byte value
+   * Appends {@code value} as a byte value
    */
   public void append(char value) {
     currentBytes.append((char) (value & 0xff));
   }
 
   /**
-   * appends {@code value} as a byte value (not it's string representation)
+   * Appends {@code value} as a byte value (not its string representation)
    */
   public void append(byte value) {
     currentBytes.append((char) (value & 0xff));
   }
 
   /**
-   * appends the characters in {@code value} as bytes values
+   * Appends the characters in {@code value} as bytes values
    */
   public void append(String value) {
     currentBytes.append(value);
   }
 
   /**
-   * append the string repesentation of {@code value} (short for {@code append(String.valueOf(value))})
+   * Append the string repesentation of {@code value} (short for {@code append(String.valueOf(value))})
    */
   public void append(int value) {
     append(String.valueOf(value));
@@ -106,7 +106,7 @@ public final class ECIStringBuilder {
   }
 
   /**
-   * short for {@code toString().length()} (if possible, use {@link #isEmpty()} instead)
+   * Short for {@code toString().length()} (if possible, use {@link #isEmpty()} instead)
    */
   public int length() {
     return toString().length();

--- a/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
+++ b/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
@@ -26,7 +26,6 @@ import java.nio.charset.StandardCharsets;
  *
  * @author Alex Geller
  */
-
 public final class ECIStringBuilder {
   private StringBuilder currentBytes;
   private StringBuilder result;
@@ -61,38 +60,35 @@ public final class ECIStringBuilder {
   }
 
   /**
-   * append the string repesentation of {@code value} (short for {@code append("" + value)})
+   * append the string repesentation of {@code value} (short for {@code append(String.valueOf(value))})
    */
   public void append(int value) {
-    append("" + value);
+    append(String.valueOf(value));
   }
 
   public void appendECI(int value) throws FormatException {
     encodeCurrentBytesIfAny();
     CharacterSetECI characterSetECI = CharacterSetECI.getCharacterSetECIByValue(value);
     if (characterSetECI == null) {
-      throw FormatException.getFormatInstance(new RuntimeException("Unsupported ECI value " + value));
+      throw FormatException.getFormatInstance();
     }
     currentCharset = characterSetECI.getCharset();
   }
 
   private void encodeCurrentBytesIfAny() {
-    if (currentCharset == StandardCharsets.ISO_8859_1) {
+    if (currentCharset.equals(StandardCharsets.ISO_8859_1)) {
       if (currentBytes.length() > 0) {
         if (result == null) {
           result = currentBytes;
           currentBytes = new StringBuilder();
         } else {
           result.append(currentBytes);
-          currentBytes.setLength(0);
+          currentBytes = new StringBuilder();
         }
       }
     } else if (currentBytes.length() > 0) {
-      byte[] bytes = new byte[currentBytes.length()];
-      for (int i = 0; i < bytes.length; i++) {
-        bytes[i] = (byte) (currentBytes.charAt(i) & 0xff);
-      }
-      currentBytes.setLength(0);
+      byte[] bytes = currentBytes.toString().getBytes(StandardCharsets.ISO_8859_1);
+      currentBytes = new StringBuilder();
       if (result == null) {
         result = new StringBuilder(new String(bytes, currentCharset));
       } else {
@@ -102,7 +98,7 @@ public final class ECIStringBuilder {
   }
 
   /**
-   * appends the characters from sb (unlike all other append methods of this class who append bytes)
+   * Appends the characters from {@code value} (unlike all other append methods of this class who append bytes)
    */
   public void appendCharacters(StringBuilder value) {
     encodeCurrentBytesIfAny();

--- a/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
+++ b/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
@@ -46,6 +46,9 @@ public final class ECIStringBuilder {
     currentBytes.append((char) (value & 0xff));
   }
 
+  /**
+   * appends {@code value} as a byte value (not it's string representation)
+   */
   public void append(byte value) {
     currentBytes.append((char) (value & 0xff));
   }
@@ -58,7 +61,7 @@ public final class ECIStringBuilder {
   }
 
   /**
-   * short for {@code append("" + value)}
+   * append the string repesentation of {@code value} (short for {@code append("" + value)})
    */
   public void append(int value) {
     append("" + value);

--- a/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
+++ b/core/src/main/java/com/google/zxing/common/ECIStringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 ZXing authors
+ * Copyright 2022 ZXing authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Class that converts a sequence of ECIs and byte into a string to be used for decoding multi-eci content
+ * Class that converts a sequence of ECIs and bytes into a string
  *
  * @author Alex Geller
  */
@@ -39,6 +39,9 @@ public final class ECIStringBuilder {
     currentBytes = new StringBuilder(initialCapacity);
   }
 
+  /**
+   * appends {@code value} as a byte value
+   */
   public void append(char value) {
     currentBytes.append((char) (value & 0xff));
   }
@@ -47,11 +50,16 @@ public final class ECIStringBuilder {
     currentBytes.append((char) (value & 0xff));
   }
 
+  /**
+   * appends the characters in {@code value} as bytes values
+   */
   public void append(String value) {
     currentBytes.append(value);
   }
 
-  /* short for {@code append("" + value)}*/
+  /**
+   * short for {@code append("" + value)}
+   */
   public void append(int value) {
     append("" + value);
   }
@@ -99,7 +107,7 @@ public final class ECIStringBuilder {
   }
 
   /**
-   * returns the length of toString()
+   * short for {@code toString().length()} (if possible, use {@link #isEmpty()} instead)
    */
   public int length() {
     return toString().length();


### PR DESCRIPTION
Besides the benefit of code reuse, the shared class is also more efficient in the no-ECI case so that the PDF417 decoder profits from that. With this PR we now have both a multi-eci encoder (..common.MinimalECIInput) and decoder (..common.ECIStringBuilder) that are shared between data-matrix and PDF417. I didn't look, but there may be other bar codes that don't yet support multi-eci, that could also make use of it. 