### PR TITLE
Replacing non ISO-8859-1 characters in PDF417 input with '?'

### DIFF
--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -174,9 +174,9 @@ final class PDF417HighLevelEncoder {
     if (encoding == null && !autoECI) {
       for (int i = 0; i < msg.length(); i++) {
         if (msg.charAt(i) > 255) {
-          //will produce '?' for characters with a value greater than 255
-          msg = new String(msg.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.ISO_8859_1);
-          break;
+          throw new WriterException("Non-encodable character detected: " + msg.charAt(i) + " (Unicode: " +
+              (int) msg.charAt(i) +
+              "). Consider specifying EncodeHintType.PDF417_AUTO_ECI and/or EncodeTypeHint.CHARACTER_SET.");
         }
       }
     }

--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -171,6 +171,15 @@ final class PDF417HighLevelEncoder {
   static String encodeHighLevel(String msg, Compaction compaction, Charset encoding, boolean autoECI) 
       throws WriterException {
 
+    if (encoding == null && !autoECI) {
+      for (int i = 0; i < msg.length(); i++) {
+        if (msg.charAt(i) > 255) {
+          //will produce '?' for characters with a value greater than 255
+          msg = new String(msg.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.ISO_8859_1);
+          break;
+        }
+      }
+    }
     //the codewords 0..928 are encoded as Unicode characters
     StringBuilder sb = new StringBuilder(msg.length());
 


### PR DESCRIPTION
… when neither a character-set nor multi-eci-encoding is selected.
This fixes issue #1163.