### PR TITLE
Adds orientation of pdf417 barcode to Result metadata

### DIFF
--- a/core/src/main/java/com/google/zxing/common/BitMatrix.java
+++ b/core/src/main/java/com/google/zxing/common/BitMatrix.java
@@ -287,6 +287,27 @@ public final class BitMatrix implements Cloneable {
   }
 
   /**
+   * Modifies this {@code BitMatrix} to represent the same but rotated the given degrees (multiple of 0, 90, 180, 270)
+   */
+  public void rotate(int degrees) {
+    switch (degrees % 360) {
+      case 0:
+        return;
+      case 90:
+        rotate90();
+        return;
+      case 180:
+        rotate180();
+        return;
+      case 270:
+        rotate90();
+        rotate180();
+        return;
+    }
+    throw new IllegalArgumentException("degrees must be a multiple of 0, 90, 180, or 270");
+  }
+
+  /**
    * Modifies this {@code BitMatrix} to represent the same but rotated 180 degrees
    */
   public void rotate180() {

--- a/core/src/main/java/com/google/zxing/pdf417/PDF417Reader.java
+++ b/core/src/main/java/com/google/zxing/pdf417/PDF417Reader.java
@@ -94,6 +94,7 @@ public final class PDF417Reader implements Reader, MultipleBarcodeReader {
       if (pdf417ResultMetadata != null) {
         result.putMetadata(ResultMetadataType.PDF417_EXTRA_METADATA, pdf417ResultMetadata);
       }
+      result.putMetadata(ResultMetadataType.ORIENTATION, detectorResult.getRotation());
       result.putMetadata(ResultMetadataType.SYMBOLOGY_IDENTIFIER, "]L" + decoderResult.getSymbologyModifier());
       results.add(result);
     }

--- a/core/src/main/java/com/google/zxing/pdf417/detector/Detector.java
+++ b/core/src/main/java/com/google/zxing/pdf417/detector/Detector.java
@@ -79,7 +79,7 @@ public final class Detector {
     //boolean tryHarder = hints != null && hints.containsKey(DecodeHintType.TRY_HARDER);
 
     BitMatrix originalMatrix = image.getBlackMatrix();
-    for(int rotation : ROTATIONS) {
+    for (int rotation : ROTATIONS) {
       BitMatrix bitMatrix = applyRotation(originalMatrix, rotation);
       List<ResultPoint[]> barcodeCoordinates = detect(multiple, bitMatrix);
       if (!barcodeCoordinates.isEmpty()) {
@@ -98,11 +98,11 @@ public final class Detector {
   private static BitMatrix applyRotation(BitMatrix matrix, int rotation) {
     if (rotation % 360 == 0) {
       return matrix;
-    } else {
-      BitMatrix newMatrix = matrix.clone();
-      newMatrix.rotate(rotation);
-      return newMatrix;
     }
+
+    BitMatrix newMatrix = matrix.clone();
+    newMatrix.rotate(rotation);
+    return newMatrix;
   }
 
   /**

--- a/core/src/main/java/com/google/zxing/pdf417/detector/Detector.java
+++ b/core/src/main/java/com/google/zxing/pdf417/detector/Detector.java
@@ -57,6 +57,7 @@ public final class Detector {
   // ensure we don't miss it.
   private static final int ROW_STEP = 5;
   private static final int BARCODE_MIN_HEIGHT = 10;
+  private static final int[] ROTATIONS = {0, 180, 270, 90};
 
   private Detector() {
   }
@@ -77,20 +78,31 @@ public final class Detector {
     // different binarizers
     //boolean tryHarder = hints != null && hints.containsKey(DecodeHintType.TRY_HARDER);
 
-    BitMatrix bitMatrix = image.getBlackMatrix();
-
-    List<ResultPoint[]> barcodeCoordinates = detect(multiple, bitMatrix);
-    // Try 180, 270, 90 degree rotations, in that order
-    for (int rotate = 0; barcodeCoordinates.isEmpty() && rotate < 3; rotate++) {
-      bitMatrix = bitMatrix.clone();
-      if (rotate != 1) {
-        bitMatrix.rotate180();
-      } else {
-        bitMatrix.rotate90();
+    BitMatrix originalMatrix = image.getBlackMatrix();
+    for(int rotation : ROTATIONS) {
+      BitMatrix bitMatrix = applyRotation(originalMatrix, rotation);
+      List<ResultPoint[]> barcodeCoordinates = detect(multiple, bitMatrix);
+      if (!barcodeCoordinates.isEmpty()) {
+        return new PDF417DetectorResult(bitMatrix, barcodeCoordinates, rotation);
       }
-      barcodeCoordinates = detect(multiple, bitMatrix);
     }
-    return new PDF417DetectorResult(bitMatrix, barcodeCoordinates);
+    return new PDF417DetectorResult(originalMatrix, new ArrayList<>(), 0);
+  }
+
+  /**
+   * Applies a rotation to the supplied BitMatrix.
+   * @param matrix bit matrix to apply rotation to
+   * @param rotation the degrees of rotation to apply
+   * @return BitMatrix with applied rotation
+   */
+  private static BitMatrix applyRotation(BitMatrix matrix, int rotation) {
+    if (rotation % 360 == 0) {
+      return matrix;
+    } else {
+      BitMatrix newMatrix = matrix.clone();
+      newMatrix.rotate(rotation);
+      return newMatrix;
+    }
   }
 
   /**

--- a/core/src/main/java/com/google/zxing/pdf417/detector/PDF417DetectorResult.java
+++ b/core/src/main/java/com/google/zxing/pdf417/detector/PDF417DetectorResult.java
@@ -28,10 +28,12 @@ public final class PDF417DetectorResult {
 
   private final BitMatrix bits;
   private final List<ResultPoint[]> points;
+  private final int rotation;
 
-  public PDF417DetectorResult(BitMatrix bits, List<ResultPoint[]> points) {
+  public PDF417DetectorResult(BitMatrix bits, List<ResultPoint[]> points, int rotation) {
     this.bits = bits;
     this.points = points;
+    this.rotation = rotation;
   }
 
   public BitMatrix getBits() {
@@ -40,6 +42,10 @@ public final class PDF417DetectorResult {
 
   public List<ResultPoint[]> getPoints() {
     return points;
+  }
+
+  public int getRotation() {
+    return rotation;
   }
 
 }

--- a/core/src/main/java/com/google/zxing/pdf417/detector/PDF417DetectorResult.java
+++ b/core/src/main/java/com/google/zxing/pdf417/detector/PDF417DetectorResult.java
@@ -36,6 +36,10 @@ public final class PDF417DetectorResult {
     this.rotation = rotation;
   }
 
+  public PDF417DetectorResult(BitMatrix bits, List<ResultPoint[]> points) {
+    this(bits, points, 0);
+  }
+
   public BitMatrix getBits() {
     return bits;
   }


### PR DESCRIPTION
Pull Request https://github.com/zxing/zxing/pull/1333 added support for scanning PDF417 barcodes at different orientations. We have a use case where we are using the orientation of the barcode to know the correct orientation of the page. With previous versions of zxing, we attempted to read barcodes from images with each orientation. With 3.5.0, the different orientations are now scanned in the Detector, with no way of the client to know which orientation the barcode was found in. This change stores the orientation in the result's metadata so that the orientation data can be used by clients of this library.

I also modified the rotation logic such that we don't clone the matrix when decoding with a rotation of 0.