### PR TITLE
add rust port (rxing) to the list of ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ library implemented in Java, with ports to other languages.
 | [zxing-js/library](https://github.com/zxing-js/library)                                   | TypeScript port of ZXing library
 | [pyzxing](https://github.com/ChenjieXu/pyzxing)                                           | Python wrapper to ZXing library
 | [zxing-dart](https://github.com/shirne/zxing-dart)                                        | Port to dart
+| [rxing](https://github.com/hschimke/rxing)                                                | Port to rust
 
 ### Other related third-party open source projects
 


### PR DESCRIPTION
Please add my port of zxing for rust to the list of ports.