### PR TITLE
fix: 1358 - rolled back to old-fashioned Collections.sort for android 23

### DIFF
--- a/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
@@ -25,6 +25,7 @@ import com.google.zxing.common.BitMatrix;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -628,7 +629,10 @@ public class FinderPatternFinder {
       }
     }
 
-    possibleCenters.sort(moduleComparator);
+    // A more up-to-date version would be "possibleCenters.sort(moduleComparator);"
+    // But we need this old syntax for android API 23 (Marshmallow) and below
+    // cf. https://github.com/zxing/zxing/issues/1358
+    Collections.sort(possibleCenters, moduleComparator);
 
     double distortion = Double.MAX_VALUE;
     FinderPattern[] bestPatterns = new FinderPattern[3];


### PR DESCRIPTION
cf. https://developer.android.com/reference/java/util/List#sort(java.util.Comparator%3C?%20super%20E%3E), "added in API level 24"