### PR TITLE
Clarify that the size of the GF is a power of two

### DIFF
--- a/core/src/main/java/com/google/zxing/common/reedsolomon/GenericGF.java
+++ b/core/src/main/java/com/google/zxing/common/reedsolomon/GenericGF.java
@@ -21,20 +21,21 @@ package com.google.zxing.common.reedsolomon;
  * the Galois Fields. Operations use a given primitive polynomial in calculations.</p>
  *
  * <p>Throughout this package, elements of the GF are represented as an {@code int}
- * for convenience and speed (but at the cost of memory).
- * </p>
+ * for convenience and speed (but at the cost of memory).</p>
+ *
+ * <p>The size of the GF is assumed to be a power of two.</p>
  *
  * @author Sean Owen
  * @author David Olivier
  */
 public final class GenericGF {
 
-  public static final GenericGF AZTEC_DATA_12 = new GenericGF(0x1069, 4096, 1); // x^12 + x^6 + x^5 + x^3 + 1
-  public static final GenericGF AZTEC_DATA_10 = new GenericGF(0x409, 1024, 1); // x^10 + x^3 + 1
-  public static final GenericGF AZTEC_DATA_6 = new GenericGF(0x43, 64, 1); // x^6 + x + 1
-  public static final GenericGF AZTEC_PARAM = new GenericGF(0x13, 16, 1); // x^4 + x + 1
-  public static final GenericGF QR_CODE_FIELD_256 = new GenericGF(0x011D, 256, 0); // x^8 + x^4 + x^3 + x^2 + 1
-  public static final GenericGF DATA_MATRIX_FIELD_256 = new GenericGF(0x012D, 256, 1); // x^8 + x^5 + x^3 + x^2 + 1
+  public static final GenericGF AZTEC_DATA_12 = new GenericGF(0b1000001101001, 4096, 1); // x^12 + x^6 + x^5 + x^3 + 1
+  public static final GenericGF AZTEC_DATA_10 = new GenericGF(0b10000001001, 1024, 1); // x^10 + x^3 + 1
+  public static final GenericGF AZTEC_DATA_6 = new GenericGF(0b1000011, 64, 1); // x^6 + x + 1
+  public static final GenericGF AZTEC_PARAM = new GenericGF(0b10011, 16, 1); // x^4 + x + 1
+  public static final GenericGF QR_CODE_FIELD_256 = new GenericGF(0b100011101, 256, 0); // x^8 + x^4 + x^3 + x^2 + 1
+  public static final GenericGF DATA_MATRIX_FIELD_256 = new GenericGF(0b100101101, 256, 1); // x^8 + x^5 + x^3 + x^2 + 1
   public static final GenericGF AZTEC_DATA_8 = DATA_MATRIX_FIELD_256;
   public static final GenericGF MAXICODE_FIELD_64 = AZTEC_DATA_6;
 
@@ -67,7 +68,7 @@ public final class GenericGF {
     int x = 1;
     for (int i = 0; i < size; i++) {
       expTable[i] = x;
-      x *= 2; // we're assuming the generator alpha is 2
+      x *= 2; // 2 (the polynomial x) is a primitive element
       if (x >= size) {
         x ^= primitive;
         x &= size - 1;


### PR DESCRIPTION
I clarified that the size of the GF is assumed to be a power of two. Even though this might be obvious, it is important to clarify. Otherwise functions like
```java
/**
 * Implements both addition and subtraction -- they are the same in GF(size).
 *
 * @return sum/difference of a and b
 */
static int addOrSubtract(int a, int b) {
  return a ^ b;
}
```
make no sense at all. For this to hold, the field needs to have characteristic two. Clarifying that the size of the GF is assumed to be power of two, this criterium is met. In these cases `2` will also always be a primitive element, which makes the comment I changed more straightforward.

I also changed the integers to be displayed in binary, reflecting the interpretation of them as primitive polynomials much better. Arguably the comments explicitly stating the polynomials could be removed now.