### PR TITLE
Ignore Eclipse IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target
 .idea
 *.iml
 .DS_Store
+.settings
+.classpath
+.project


### PR DESCRIPTION
The IntelliJ IDEA project files are already ignored -- adding Eclipse IDE project files to the ignore list.