### PR TITLE
Allow space in Code128 CodeSet B

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/Code128Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/Code128Writer.java
@@ -137,7 +137,7 @@ public final class Code128Writer extends OneDimensionalCodeWriter {
           break;
         case CODE_CODE_B:
           // allows no ascii below 32 (terminal symbols)
-          if (c <= 32) {
+          if (c < 32) {
             throw new IllegalArgumentException("Bad character in input for forced code set B: ASCII value=" + (int) c);
           }
           break;


### PR DESCRIPTION
Space is a valid character in CodeSet B.