### PR TITLE
Make OneDimensionalCodeWriter.encode(content, hints) public

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/Code128Writer.java
+++ b/core/src/main/java/com/google/zxing/oned/Code128Writer.java
@@ -71,7 +71,7 @@ public final class Code128Writer extends OneDimensionalCodeWriter {
   }
 
   @Override
-  protected boolean[] encode(String contents, Map<EncodeHintType,?> hints) {
+  public boolean[] encode(String contents, Map<EncodeHintType,?> hints) {
 
     int forcedCodeSet = check(contents, hints);
 

--- a/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
+++ b/core/src/main/java/com/google/zxing/oned/OneDimensionalCodeWriter.java
@@ -48,7 +48,7 @@ public abstract class OneDimensionalCodeWriter implements Writer {
    * @param hints encoding hints
    * @return a {@code boolean[]} of horizontal pixels (false = white, true = black)
    */
-  protected boolean[] encode(String contents, Map<EncodeHintType,?> hints) {
+  public boolean[] encode(String contents, Map<EncodeHintType,?> hints) {
     return encode(contents);
   }
 


### PR DESCRIPTION
This method is useful for encoding Code128 with a specific code set to a bool array. As no other class overrides this method, this change only affects Code128Writer.

I don't know that there's a strong argument against making this method public. With this method protected, it is necessary to first encode as a BitMatrix, extract the first row, and the convert the resulting BitArray to a bool array. This all can be avoided if the method is made public.