### PR TITLE
Add documentation for building source and minimum requirements/spec 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ library implemented in Java, with ports to other languages.
   * [Javadoc](https://zxing.github.io/zxing/apidocs/)
   * [Documentation Site](https://zxing.github.io/zxing/)
 
+## Recommended Test Environment
+
+If you want to run the tests of this project, it is recommended to have a machine or virtual machine with the following specifications to avoid intermittent test failures (i.e., flaky tests).
+
+* Minumum of 2CPUs.
+* Minimum of 2Gb of RAM.
+
 ## Contacting
 
 Post to the [discussion forum](https://groups.google.com/group/zxing) or tag a question with [`zxing`


### PR DESCRIPTION
This PR fix #1688.

This edition aims to prevent potential flaky test scenarios that may occur for other users or contributors in their machines.

The main goal of our contribution is to educate developers and users about the importance of having a minimum requirement for stable test execution. By specifying the minimum required RAM and CPU in the README, we can avoid unexpected test failures caused by insufficient resources on developers' machines.

Including this information requires minimal effort, yet it can save developers from the frustration of debugging flaky test failures if their machines don't meet the recommended specifications.