### PR TITLE
Support for platforms where SJIS is unavailable

### DIFF
--- a/core/src/main/java/com/google/zxing/common/StringUtils.java
+++ b/core/src/main/java/com/google/zxing/common/StringUtils.java
@@ -54,10 +54,20 @@ public final class StringUtils {
     }
     GB2312_CHARSET = gb2312Charset;
   }
-  private static final Charset EUC_JP = Charset.forName("EUC_JP");
+  private static final Charset EUC_JP;
+  static {
+    Charset eucJpCharset;
+    try {
+      eucJpCharset = Charset.forName("EUC_JP");
+    } catch (UnsupportedCharsetException ucee) {
+      // Can happen on JREs without lib/charsets.jar
+      eucJpCharset = null;
+    }
+    EUC_JP = eucJpCharset;
+  }
   private static final boolean ASSUME_SHIFT_JIS =
       (SHIFT_JIS_CHARSET != null && SHIFT_JIS_CHARSET.equals(PLATFORM_DEFAULT_ENCODING)) ||
-      EUC_JP.equals(PLATFORM_DEFAULT_ENCODING);
+      (EUC_JP != null && EUC_JP.equals(PLATFORM_DEFAULT_ENCODING));
 
   // Retained for ABI compatibility with earlier versions
   public static final String SHIFT_JIS = "SJIS";

--- a/core/src/main/java/com/google/zxing/common/StringUtils.java
+++ b/core/src/main/java/com/google/zxing/common/StringUtils.java
@@ -32,7 +32,17 @@ import com.google.zxing.DecodeHintType;
 public final class StringUtils {
 
   private static final Charset PLATFORM_DEFAULT_ENCODING = Charset.defaultCharset();
-  public static final Charset SHIFT_JIS_CHARSET = Charset.forName("SJIS");
+  public static final Charset SHIFT_JIS_CHARSET;
+  static {
+    Charset sjisCharset;
+    try {
+      sjisCharset = Charset.forName("SJIS");
+    } catch (UnsupportedCharsetException ucee) {
+      // Can happen on JREs without lib/charsets.jar
+      sjisCharset = null;
+    }
+    SHIFT_JIS_CHARSET = sjisCharset;
+  }
   public static final Charset GB2312_CHARSET;
   static {
     Charset gb2312Charset;
@@ -46,7 +56,7 @@ public final class StringUtils {
   }
   private static final Charset EUC_JP = Charset.forName("EUC_JP");
   private static final boolean ASSUME_SHIFT_JIS =
-      SHIFT_JIS_CHARSET.equals(PLATFORM_DEFAULT_ENCODING) ||
+      (SHIFT_JIS_CHARSET != null && SHIFT_JIS_CHARSET.equals(PLATFORM_DEFAULT_ENCODING)) ||
       EUC_JP.equals(PLATFORM_DEFAULT_ENCODING);
 
   // Retained for ABI compatibility with earlier versions
@@ -101,7 +111,7 @@ public final class StringUtils {
     // which should be by far the most common encodings.
     int length = bytes.length;
     boolean canBeISO88591 = true;
-    boolean canBeShiftJIS = true;
+    boolean canBeShiftJIS = SHIFT_JIS_CHARSET != null;
     boolean canBeUTF8 = true;
     int utf8BytesLeft = 0;
     int utf2BytesChars = 0;

--- a/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java
@@ -211,6 +211,10 @@ final class DecodedBitStreamParser {
   private static void decodeKanjiSegment(BitSource bits,
                                          StringBuilder result,
                                          int count) throws FormatException {
+    if (StringUtils.SHIFT_JIS_CHARSET == null) {
+      // Not supported without charset support
+      throw FormatException.getFormatInstance();
+    }
     // Don't crash trying to read more bits than we have available.
     if (count * 13 > bits.available()) {
       throw FormatException.getFormatInstance();


### PR DESCRIPTION
Certain embedded JREs do not include lib/charsets.jar  This means that these platforms don't support Charsets outside of the six [standard Charsets](https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html).  

#1330 made the assumption that the Shift JIS Charset *would* be available, so on platforms without Shift JIS support, attempting to load QRCodeWriter results in an UnsupportedCharsetException before attempting to encode any text.

This change, like the change in commit [a6273e3](https://github.com/zxing/zxing/commit/a6273e3bc788135e4ad755fe6a7c1a4bf74fcdc9), handles UnsupportedCharsetExceptions in the static initializers, then checks for the properly loaded SJIS Charset during encode and decode operations.

So as to not introduce any new test dependencies, the *tests* still assume that the Shirt JIS and EUC_JP Charsets will be available.