### PR TITLE
Update jcommander 1.82 -> 1.83

### DIFF
--- a/javase/pom.xml
+++ b/javase/pom.xml
@@ -27,9 +27,9 @@
       <artifactId>core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.beust</groupId>
+      <groupId>org.jcommander</groupId>
       <artifactId>jcommander</artifactId>
-      <version>1.82</version>
+      <version>1.83</version>
     </dependency>
     <dependency>
       <groupId>com.github.jai-imageio</groupId>


### PR DESCRIPTION
Also, switches to current artifact name `org.jcommander:jcommander`

https://jcommander.org/#_download

https://github.com/cbeust/jcommander/compare/1.82...1.83