### PR TITLE
Fix SYMBOLOGY_IDENTIFIER Loss in QRCodeMultiReader to Ensure Data Integrity and Functional Consistency with QRCodeReader

### DIFF
--- a/core/src/main/java/com/google/zxing/multi/qrcode/QRCodeMultiReader.java
+++ b/core/src/main/java/com/google/zxing/multi/qrcode/QRCodeMultiReader.java
@@ -83,6 +83,9 @@ public final class QRCodeMultiReader extends QRCodeReader implements MultipleBar
           result.putMetadata(ResultMetadataType.STRUCTURED_APPEND_PARITY,
                              decoderResult.getStructuredAppendParity());
         }
+        // Fix SYMBOLOGY_IDENTIFIER loss in QRCodeMultiReader
+        result.putMetadata(ResultMetadataType.SYMBOLOGY_IDENTIFIER, "]Q" + decoderResult.getSymbologyModifier());
+
         results.add(result);
       } catch (ReaderException re) {
         // ignore and continue


### PR DESCRIPTION
#### Background
The current use of `QRCodeMultiReader` has an issue with the loss of `SYMBOLOGY_IDENTIFIER`. This affects the ability to accurately determine if a QR code is GS1-compliant, as GS1-QR codes can be identified by the `SYMBOLOGY_IDENTIFIER` field being `]Q3` (refer to [GS1 Barcode Specifications](https://www.gs1.org/docs/barcodes/GS1_Barcodes_Fact_Sheet-GS1_2D_symbols.pdf)).

#### Changes
Added handling logic for `SYMBOLOGY_IDENTIFIER` in the `QRCodeMultiReader` class, incorporating it into the decoding result metadata.

#### Benefits
- **Data Integrity**: Ensures the `SYMBOLOGY_IDENTIFIER` information is preserved, improving the completeness of decoding results.
- **Compatibility**: Enhances support for applications that require `SYMBOLOGY_IDENTIFIER` information, such as ]Q3 for GS1-QR.
- **Functional Consistency**: Aligns `QRCodeMultiReader` capabilities with those of `QRCodeReader`.

#### Technical Details
- Added `result.putMetadata(ResultMetadataType.SYMBOLOGY_IDENTIFIER, "]Q" + decoderResult.getSymbologyModifier());` in the `decodeMultiple` method.

### Reference
- [GS1 Barcode Specifications](https://www.gs1.org/docs/barcodes/GS1_Barcodes_Fact_Sheet-GS1_2D_symbols.pdf)
- [QRCodeReader IMPL](https://github.com/zxing/zxing/blob/282f5ba726dfe3ff770b0abdcaf7cfce9700758e/core/src/main/java/com/google/zxing/qrcode/QRCodeReader.java#L103)