### PR TITLE
PDF417: Check that input is made of 0...127 chars when using Compaction.TEXT, throw an explicit exception if not the case

### DIFF
--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -176,11 +176,11 @@ final class PDF417HighLevelEncoder {
     }
     
     if (Compaction.TEXT == compaction) {
-      checkCharset(msg,127,"Consider specifying Compaction.AUTO instead of Compaction.TEXT");
+      checkCharset(msg, 127, "Consider specifying Compaction.AUTO instead of Compaction.TEXT");
     }
 
     if (encoding == null && !autoECI) {
-      checkCharset(msg,255,"Consider specifying EncodeHintType.PDF417_AUTO_ECI and/or EncodeTypeHint.CHARACTER_SET.");
+      checkCharset(msg, 255, "Consider specifying EncodeHintType.PDF417_AUTO_ECI and/or EncodeTypeHint.CHARACTER_SET");
     }
 
     //the codewords 0..928 are encoded as Unicode characters
@@ -290,7 +290,7 @@ final class PDF417HighLevelEncoder {
    * @param errorMessage   the message to explain the error
    * @throws WriterException exception highlighting the offending character and a suggestion to avoid the error
    */
-  protected static void checkCharset(String input,int max, String errorMessage) throws WriterException {
+  protected static void checkCharset(String input, int max, String errorMessage) throws WriterException {
     for (int i = 0; i < input.length(); i++) {
       if (input.charAt(i) > max) {
         throw new WriterException("Non-encodable character detected: " + input.charAt(i) + " (Unicode: " +

--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -174,6 +174,16 @@ final class PDF417HighLevelEncoder {
     if (msg.isEmpty()) {
       throw new WriterException("Empty message not allowed");
     }
+    
+    if (Compaction.TEXT == compaction) {
+      for (int i = 0; i < msg.length(); i++) {
+        if (msg.charAt(i) > 255) {
+          throw new WriterException("Non-encodable character detected: " + msg.charAt(i) + " (Unicode: " +
+            (int) msg.charAt(i) +
+            "). Consider specifying Compaction.AUTO instead of Compaction.TEXT");
+        }
+      }
+    }
 
     if (encoding == null && !autoECI) {
       for (int i = 0; i < msg.length(); i++) {

--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -176,7 +176,7 @@ final class PDF417HighLevelEncoder {
     }
     
     if (Compaction.TEXT == compaction) {
-      checkCharset(msg,255,"Consider specifying Compaction.AUTO instead of Compaction.TEXT");
+      checkCharset(msg,127,"Consider specifying Compaction.AUTO instead of Compaction.TEXT");
     }
 
     if (encoding == null && !autoECI) {
@@ -294,7 +294,7 @@ final class PDF417HighLevelEncoder {
     for (int i = 0; i < input.length(); i++) {
       if (input.charAt(i) > max) {
         throw new WriterException("Non-encodable character detected: " + input.charAt(i) + " (Unicode: " +
-                (int) input.charAt(i) + "). " + errorMessage);
+                (int) input.charAt(i) + ") at position #" + i + " - " + errorMessage);
       }
     } 
   }

--- a/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
+++ b/core/src/main/java/com/google/zxing/pdf417/encoder/PDF417HighLevelEncoder.java
@@ -176,24 +176,13 @@ final class PDF417HighLevelEncoder {
     }
     
     if (Compaction.TEXT == compaction) {
-      for (int i = 0; i < msg.length(); i++) {
-        if (msg.charAt(i) > 255) {
-          throw new WriterException("Non-encodable character detected: " + msg.charAt(i) + " (Unicode: " +
-            (int) msg.charAt(i) +
-            "). Consider specifying Compaction.AUTO instead of Compaction.TEXT");
-        }
-      }
+      checkCharset(msg,255,"Consider specifying Compaction.AUTO instead of Compaction.TEXT");
     }
 
     if (encoding == null && !autoECI) {
-      for (int i = 0; i < msg.length(); i++) {
-        if (msg.charAt(i) > 255) {
-          throw new WriterException("Non-encodable character detected: " + msg.charAt(i) + " (Unicode: " +
-              (int) msg.charAt(i) +
-              "). Consider specifying EncodeHintType.PDF417_AUTO_ECI and/or EncodeTypeHint.CHARACTER_SET.");
-        }
-      }
+      checkCharset(msg,255,"Consider specifying EncodeHintType.PDF417_AUTO_ECI and/or EncodeTypeHint.CHARACTER_SET.");
     }
+
     //the codewords 0..928 are encoded as Unicode characters
     StringBuilder sb = new StringBuilder(msg.length());
 
@@ -292,6 +281,22 @@ final class PDF417HighLevelEncoder {
     }
 
     return sb.toString();
+  }
+  
+  /**
+   * Check if input is only made of characters between 0 and the upper limit 
+   * @param input          the input
+   * @param max            the upper limit for charset
+   * @param errorMessage   the message to explain the error
+   * @throws WriterException exception highlighting the offending character and a suggestion to avoid the error
+   */
+  protected static void checkCharset(String input,int max, String errorMessage) throws WriterException {
+    for (int i = 0; i < input.length(); i++) {
+      if (input.charAt(i) > max) {
+        throw new WriterException("Non-encodable character detected: " + input.charAt(i) + " (Unicode: " +
+                (int) input.charAt(i) + "). " + errorMessage);
+      }
+    } 
   }
 
   /**

--- a/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
@@ -90,10 +90,10 @@ public final class PDF417EncoderTestCase extends Assert {
       String content = "€ 123,45";
       Map<EncodeHintType, Object> hints = new HashMap<>();
       hints.put(EncodeHintType.ERROR_CORRECTION, 4);
-      hints.put(EncodeHintType.PDF417_DIMENSIONS, new com.google.zxing.pdf417.encoder.Dimensions(7, 7, 1, 300));
+      hints.put(EncodeHintType.PDF417_DIMENSIONS, new Dimensions(7, 7, 1, 300));
       hints.put(EncodeHintType.MARGIN, 0);
       hints.put(EncodeHintType.CHARACTER_SET, "ISO-8859-15");
-      hints.put(EncodeHintType.PDF417_COMPACTION, com.google.zxing.pdf417.encoder.Compaction.TEXT);
+      hints.put(EncodeHintType.PDF417_COMPACTION, Compaction.TEXT);
       
       (new MultiFormatWriter()).encode(content, BarcodeFormat.PDF_417, 200, 100, hints);
     } catch (WriterException e) {

--- a/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
@@ -35,7 +35,13 @@ import org.junit.Test;
  * Tests {@link PDF417HighLevelEncoder}.
  */
 public final class PDF417EncoderTestCase extends Assert {
-
+  private static final String PDF417PFX = "\u039f\u001A\u0385";
+  @Test
+  public void testEncodeAuto() throws Exception {
+    String input = "ABCD";
+    assertEquals(PDF417PFX + input, checkEncodeAutoWithSpecialChars(input, Compaction.AUTO));
+  }
+  
   @Test
   public void testEncodeAutoWithSpecialChars() throws Exception {
     // Just check if this does not throw an exception
@@ -98,8 +104,8 @@ public final class PDF417EncoderTestCase extends Assert {
     }
   }
   
-  public void checkEncodeAutoWithSpecialChars(String input, Compaction compaction) throws Exception {
-    PDF417HighLevelEncoder.encodeHighLevel(input, compaction, StandardCharsets.UTF_8, false);
+  public String checkEncodeAutoWithSpecialChars(String input, Compaction compaction) throws Exception {
+    return PDF417HighLevelEncoder.encodeHighLevel(input, compaction, StandardCharsets.UTF_8, false);
   }
 
   @Test

--- a/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
@@ -35,7 +35,9 @@ import org.junit.Test;
  * Tests {@link PDF417HighLevelEncoder}.
  */
 public final class PDF417EncoderTestCase extends Assert {
+
   private static final String PDF417PFX = "\u039f\u001A\u0385";
+
   @Test
   public void testEncodeAuto() throws Exception {
     String input = "ABCD";

--- a/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/encoder/PDF417EncoderTestCase.java
@@ -18,6 +18,7 @@ package com.google.zxing.pdf417.encoder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.EncodeHintType;
@@ -76,6 +77,26 @@ public final class PDF417EncoderTestCase extends Assert {
       assertTrue(e.getMessage().contains("8364"));
       assertTrue(e.getMessage().contains("Compaction.TEXT"));
       assertTrue(e.getMessage().contains("Compaction.AUTO"));
+    }
+  }
+
+  @Test
+  public void testCheckCharset() throws Exception {
+    String input = "Hello!";
+    String errorMessage = UUID.randomUUID().toString();
+    
+    // no exception
+    PDF417HighLevelEncoder.checkCharset(input,255,errorMessage);
+    PDF417HighLevelEncoder.checkCharset(input,1255,errorMessage);
+    PDF417HighLevelEncoder.checkCharset(input,111,errorMessage);
+    
+    try {
+      // should throw an exception for character 'o' because it exceeds upper limit 110
+      PDF417HighLevelEncoder.checkCharset(input,110,errorMessage);
+    } catch (WriterException e) {
+      assertNotNull(e.getMessage());
+      assertTrue(e.getMessage().contains("111"));
+      assertTrue(e.getMessage().contains(errorMessage));
     }
   }
   


### PR DESCRIPTION
- [x] when encoding a PDF417 with TEXT compaction, check if input is made of chars in the 0...127 range
- [x] if not, throw an exception recommending the use of AUTO compaction instead
- [x] add UT to test the above changes

Fixes #1761   