### PR TITLE
Add input validation for pixel array length in RGBLuminanceSource to avoid ArrayIndexOutOfBoundsException

### DIFF
--- a/core/src/main/java/com/google/zxing/RGBLuminanceSource.java
+++ b/core/src/main/java/com/google/zxing/RGBLuminanceSource.java
@@ -44,6 +44,9 @@ public final class RGBLuminanceSource extends LuminanceSource {
     //
     // Total number of pixels suffices, can ignore shape
     int size = width * height;
+    if (pixels == null || pixels.length < size) {
+      throw new IllegalArgumentException("Pixel array length is less than width * height");
+    }
     luminances = new byte[size];
     for (int offset = 0; offset < size; offset++) {
       int pixel = pixels[offset];

--- a/core/src/test/java/com/google/zxing/RGBLuminanceSourceTestCase.java
+++ b/core/src/test/java/com/google/zxing/RGBLuminanceSourceTestCase.java
@@ -60,4 +60,19 @@ public final class RGBLuminanceSourceTestCase extends Assert {
     assertEquals("#+ \n#+#\n#+#\n", SOURCE.toString());
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullPixelArray() {
+    // Test regression: null pixel array should throw IllegalArgumentException
+    new RGBLuminanceSource(3, 3, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPixelArrayTooSmall() {
+    // Test regression: pixel array smaller than width * height should throw IllegalArgumentException
+    int width = 3;
+    int height = 3;
+    int[] pixels = new int[width * height - 1]; // One pixel short
+    new RGBLuminanceSource(width, height, pixels);
+  }  
+
 }


### PR DESCRIPTION
**Problem**:
The constructor of RGBLuminanceSource does not validate the length of the pixels array. If the array is shorter than [width * height], it throws an ArrayIndexOutOfBoundsException during initialization:

```
for (int offset = 0; offset < size; offset++) {
  int pixel = pixels[offset]; // <-- can throw ArrayIndexOutOfBoundsException
  ...
}
```
**Example**:
`new RGBLuminanceSource(10, 10, new int[0])`

**Fix**:
Add an explicit check at the start of the constructor to validate the array length and throw an IllegalArgumentException with a clear message if the input is invalid:
```
public RGBLuminanceSource(int width, int height, int[] pixels) {
  super(width, height);

  int size = width * height;
  if (pixels.length < size) {
    throw new IllegalArgumentException("Pixel array length is less than width * height");
  }
  // ...rest of the code...
}
```
