### PR TITLE
Remove broken links to Play Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ library implemented in Java, with ports to other languages.
 | ------------------- | -----------
 | core                | The core image decoding library, and test code
 | javase              | JavaSE-specific client code
-| android             | Android client Barcode Scanner [<img height='62' width='161' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>](https://play.google.com/store/apps/details?id=com.google.zxing.client.android)
+| android             | Android client Barcode Scanner 
 | android-integration | Supports integration with Barcode Scanner via `Intent`
 | android-core        | Android-related code shared among `android`, other Android apps
 | zxingorg            | The source behind `zxing.org`

--- a/zxingorg/src/main/webapp/w/decode.jspx
+++ b/zxingorg/src/main/webapp/w/decode.jspx
@@ -76,10 +76,6 @@
 
       <p>This web application is powered by the barcode scanning implementation in the
         open source <a href="https://github.com/zxing/zxing">ZXing</a> project.</p>
-      <p>Android users may download the
-        <a href="https://play.google.com/store/apps/details?id=com.google.zxing.client.android">Barcode Scanner</a> or
-        <a href="https://play.google.com/store/apps/details?id=com.srowen.bs.android">Barcode Scanner+</a> application
-        to access the same decoding as a mobile application.</p>
       <p style="font-style:italic">Copyright 2008 and onwards ZXing authors</p>
     </div>
   </body>


### PR DESCRIPTION
As the app isn't on the Play Store any more (RIP!) I've removed the links from the readme and the website.