### PR TITLE
Add 90-degree rotation support to RGBLuminanceSource

### DIFF
--- a/core/src/main/java/com/google/zxing/RGBLuminanceSource.java
+++ b/core/src/main/java/com/google/zxing/RGBLuminanceSource.java
@@ -18,7 +18,7 @@ package com.google.zxing;
 
 /**
  * This class is used to help decode images from files which arrive as RGB data from
- * an ARGB pixel array. It does not support rotation.
+ * an ARGB pixel array.
  *
  * @author dswitkin@google.com (Daniel Switkin)
  * @author Betaminos
@@ -133,4 +133,27 @@ public final class RGBLuminanceSource extends LuminanceSource {
                                   height);
   }
 
+  @Override
+  public boolean isRotateSupported() {
+    return true;
+  }
+
+  @Override
+  public LuminanceSource rotateCounterClockwise() {
+    byte[] rotated = new byte[luminances.length];
+    for (int y = 0; y < dataHeight; y++) {
+      for (int x = 0; x < dataWidth; x++) {
+        int i = (y * dataWidth) + x;
+        int x2 = y;
+        int y2 = dataWidth - 1 - x;
+        int j = (y2 * dataHeight) + x2;
+        rotated[j] = luminances[i];
+      }
+    }
+    int newWidth = getHeight();
+    int newHeight = getWidth();
+    int newLeft = top;
+    int newTop = dataWidth - (left + getWidth());
+    return new RGBLuminanceSource(rotated, dataHeight, dataWidth, newLeft, newTop, newWidth, newHeight);
+  }
 }

--- a/core/src/test/java/com/google/zxing/RGBLuminanceSourceTestCase.java
+++ b/core/src/test/java/com/google/zxing/RGBLuminanceSourceTestCase.java
@@ -39,6 +39,53 @@ public final class RGBLuminanceSourceTestCase extends Assert {
   }
 
   @Test
+  public void testRotate() {
+    assertTrue(SOURCE.isRotateSupported());
+    assertArrayEquals(new byte[] { 0x00, 0x7F, (byte) 0xFF}, SOURCE.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, SOURCE.getRow(1, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, SOURCE.getRow(2, null));
+    LuminanceSource rot90 = SOURCE.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { (byte) 0xFF, 0x3F, 0x3F}, rot90.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x7F, 0x7F}, rot90.getRow(1, null));
+    assertArrayEquals(new byte[] { 0x00, 0x3F, 0x3F}, rot90.getRow(2, null));
+    LuminanceSource rot180 = rot90.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, rot180.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, rot180.getRow(1, null));
+    assertArrayEquals(new byte[] { (byte) 0xFF, 0x7F, 0x00}, rot180.getRow(2, null));
+    LuminanceSource rot270 = rot180.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x3F, 0x3F, 0x00}, rot270.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x7F, 0x7F}, rot270.getRow(1, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x3F, (byte) 0xFF}, rot270.getRow(2, null));
+    LuminanceSource rot360 = rot270.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x00, 0x7F, (byte) 0xFF}, rot360.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, rot360.getRow(1, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, rot360.getRow(2, null));
+    assertArrayEquals(SOURCE.getMatrix(), rot360.getMatrix());
+  }
+
+  @Test
+  public void testRotateCropped() {
+    assertTrue(SOURCE.isCropSupported());
+    assertTrue(SOURCE.isRotateSupported());
+    LuminanceSource cropped = SOURCE.crop(1, 1, 2, 2);
+    assertArrayEquals(new byte[] { 0x7F, 0x3F}, cropped.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x3F}, cropped.getRow(1, null));
+    LuminanceSource rot90 = cropped.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x3F, 0x3F}, rot90.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x7F}, rot90.getRow(1, null));
+    LuminanceSource rot180 = rot90.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x3F, 0x7F}, rot180.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F}, rot180.getRow(1, null));
+    LuminanceSource rot270 = rot180.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x7F, 0x7F}, rot270.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x3F}, rot270.getRow(1, null));
+    LuminanceSource rot360 = rot270.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x7F, 0x3F}, rot360.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x3F}, rot360.getRow(1, null));
+    assertArrayEquals(cropped.getMatrix(), rot360.getMatrix());
+  }
+
+  @Test
   public void testMatrix() {
     assertArrayEquals(new byte[] { 0x00, 0x7F, (byte) 0xFF, 0x3F, 0x7F, 0x3F, 0x3F, 0x7F, 0x3F },
                       SOURCE.getMatrix());


### PR DESCRIPTION
Adds support for 90-degree rotation to `RGBLuminanceSource`, so that `OneDReader` can try harder, if asked to.

Does not add support for 45-degree rotation to `RGBLuminanceSource` (this type of rotation doesn't seem to be used anywhere).