### PR TITLE
Add GrayscaleLuminanceSource

### DIFF
--- a/core/src/main/java/com/google/zxing/GrayscaleLuminanceSource.java
+++ b/core/src/main/java/com/google/zxing/GrayscaleLuminanceSource.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2009 ZXing authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zxing;
+
+/**
+ * This class is used to help decode images from files which arrive as a grayscale
+ * pixel array.
+ *
+ * @author dswitkin@google.com (Daniel Switkin)
+ * @author Betaminos
+ */
+public class GrayscaleLuminanceSource extends LuminanceSource {
+
+  private final byte[] luminances;
+  private final int dataWidth;
+  private final int dataHeight;
+  private final int left;
+  private final int top;
+
+  public GrayscaleLuminanceSource(int width, int height, byte[] pixels) {
+    super(width, height);
+    luminances = pixels;
+    dataWidth = width;
+    dataHeight = height;
+    left = 0;
+    top = 0;
+  }
+
+  private GrayscaleLuminanceSource(byte[] pixels,
+                                   int dataWidth,
+                                   int dataHeight,
+                                   int left,
+                                   int top,
+                                   int width,
+                                   int height) {
+    super(width, height);
+    if (left + width > dataWidth || top + height > dataHeight) {
+      throw new IllegalArgumentException("Crop rectangle does not fit within image data.");
+    }
+    this.luminances = pixels;
+    this.dataWidth = dataWidth;
+    this.dataHeight = dataHeight;
+    this.left = left;
+    this.top = top;
+  }
+
+  @Override
+  public byte[] getRow(int y, byte[] row) {
+    if (y < 0 || y >= getHeight()) {
+      throw new IllegalArgumentException("Requested row is outside the image: " + y);
+    }
+    int width = getWidth();
+    if (row == null || row.length < width) {
+      row = new byte[width];
+    }
+    int offset = (y + top) * dataWidth + left;
+    System.arraycopy(luminances, offset, row, 0, width);
+    return row;
+  }
+
+  @Override
+  public byte[] getMatrix() {
+    int width = getWidth();
+    int height = getHeight();
+
+    // If the caller asks for the entire underlying image, save the copy and give them the
+    // original data. The docs specifically warn that result.length must be ignored.
+    if (width == dataWidth && height == dataHeight) {
+      return luminances;
+    }
+
+    int area = width * height;
+    byte[] matrix = new byte[area];
+    int inputOffset = top * dataWidth + left;
+
+    // If the width matches the full width of the underlying data, perform a single copy.
+    if (width == dataWidth) {
+      System.arraycopy(luminances, inputOffset, matrix, 0, area);
+      return matrix;
+    }
+
+    // Otherwise copy one cropped row at a time.
+    for (int y = 0; y < height; y++) {
+      int outputOffset = y * width;
+      System.arraycopy(luminances, inputOffset, matrix, outputOffset, width);
+      inputOffset += dataWidth;
+    }
+    return matrix;
+  }
+
+  @Override
+  public boolean isCropSupported() {
+    return true;
+  }
+
+  @Override
+  public LuminanceSource crop(int left, int top, int width, int height) {
+    return new GrayscaleLuminanceSource(luminances,
+                                        dataWidth,
+                                        dataHeight,
+                                        this.left + left,
+                                        this.top + top,
+                                        width,
+                                        height);
+  }
+
+  @Override
+  public boolean isRotateSupported() {
+    return true;
+  }
+
+  @Override
+  public LuminanceSource rotateCounterClockwise() {
+    byte[] rotated = new byte[luminances.length];
+    for (int y = 0; y < dataHeight; y++) {
+      for (int x = 0; x < dataWidth; x++) {
+        int i = (y * dataWidth) + x;
+        int x2 = y;
+        int y2 = dataWidth - 1 - x;
+        int j = (y2 * dataHeight) + x2;
+        rotated[j] = luminances[i];
+      }
+    }
+    int newWidth = getHeight();
+    int newHeight = getWidth();
+    int newLeft = top;
+    int newTop = dataWidth - (left + getWidth());
+    return new GrayscaleLuminanceSource(rotated, dataHeight, dataWidth, newLeft, newTop, newWidth, newHeight);
+  }
+}

--- a/core/src/test/java/com/google/zxing/GrayscaleLuminanceSourceTestCase.java
+++ b/core/src/test/java/com/google/zxing/GrayscaleLuminanceSourceTestCase.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014 ZXing authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zxing;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests {@link GrayscaleLuminanceSource}.
+ */
+public final class GrayscaleLuminanceSourceTestCase extends Assert {
+
+  private static final GrayscaleLuminanceSource SOURCE =
+      new GrayscaleLuminanceSource(3, 3, new byte[] {
+        0x00, 0x7F, (byte) 0xFF,
+        0x3F, 0x7F, 0x3F,
+        0x3F, 0x7F, 0x3F});
+
+  @Test
+  public void testCrop() {
+    assertTrue(SOURCE.isCropSupported());
+    LuminanceSource cropped = SOURCE.crop(1, 1, 1, 1);
+    assertEquals(1, cropped.getHeight());
+    assertEquals(1, cropped.getWidth());
+    assertArrayEquals(new byte[] { 0x7F }, cropped.getRow(0, null));
+  }
+
+  @Test
+  public void testRotate() {
+    assertTrue(SOURCE.isRotateSupported());
+    assertArrayEquals(new byte[] { 0x00, 0x7F, (byte) 0xFF}, SOURCE.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, SOURCE.getRow(1, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, SOURCE.getRow(2, null));
+    LuminanceSource rot90 = SOURCE.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { (byte) 0xFF, 0x3F, 0x3F}, rot90.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x7F, 0x7F}, rot90.getRow(1, null));
+    assertArrayEquals(new byte[] { 0x00, 0x3F, 0x3F}, rot90.getRow(2, null));
+    LuminanceSource rot180 = rot90.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, rot180.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, rot180.getRow(1, null));
+    assertArrayEquals(new byte[] { (byte) 0xFF, 0x7F, 0x00}, rot180.getRow(2, null));
+    LuminanceSource rot270 = rot180.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x3F, 0x3F, 0x00}, rot270.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x7F, 0x7F}, rot270.getRow(1, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x3F, (byte) 0xFF}, rot270.getRow(2, null));
+    LuminanceSource rot360 = rot270.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x00, 0x7F, (byte) 0xFF}, rot360.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, rot360.getRow(1, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F}, rot360.getRow(2, null));
+    assertArrayEquals(SOURCE.getMatrix(), rot360.getMatrix());
+  }
+
+  @Test
+  public void testRotateCropped() {
+    assertTrue(SOURCE.isCropSupported());
+    assertTrue(SOURCE.isRotateSupported());
+    LuminanceSource cropped = SOURCE.crop(1, 1, 2, 2);
+    assertArrayEquals(new byte[] { 0x7F, 0x3F}, cropped.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x3F}, cropped.getRow(1, null));
+    LuminanceSource rot90 = cropped.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x3F, 0x3F}, rot90.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x7F}, rot90.getRow(1, null));
+    LuminanceSource rot180 = rot90.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x3F, 0x7F}, rot180.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x7F}, rot180.getRow(1, null));
+    LuminanceSource rot270 = rot180.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x7F, 0x7F}, rot270.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x3F, 0x3F}, rot270.getRow(1, null));
+    LuminanceSource rot360 = rot270.rotateCounterClockwise();
+    assertArrayEquals(new byte[] { 0x7F, 0x3F}, rot360.getRow(0, null));
+    assertArrayEquals(new byte[] { 0x7F, 0x3F}, rot360.getRow(1, null));
+    assertArrayEquals(cropped.getMatrix(), rot360.getMatrix());
+  }
+
+  @Test
+  public void testMatrix() {
+    assertArrayEquals(new byte[] { 0x00, 0x7F, (byte) 0xFF, 0x3F, 0x7F, 0x3F, 0x3F, 0x7F, 0x3F },
+                      SOURCE.getMatrix());
+    LuminanceSource croppedFullWidth = SOURCE.crop(0, 1, 3, 2);
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F, 0x3F, 0x7F, 0x3F },
+                      croppedFullWidth.getMatrix());
+    LuminanceSource croppedCorner = SOURCE.crop(1, 1, 2, 2);
+    assertArrayEquals(new byte[] { 0x7F, 0x3F, 0x7F, 0x3F },
+                      croppedCorner.getMatrix());
+  }
+
+  @Test
+  public void testGetRow() {
+    assertArrayEquals(new byte[] { 0x3F, 0x7F, 0x3F }, SOURCE.getRow(2, new byte[3]));
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals("#+ \n#+#\n#+#\n", SOURCE.toString());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullPixelArray() {
+    // Test regression: null pixel array should throw IllegalArgumentException
+    new RGBLuminanceSource(3, 3, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPixelArrayTooSmall() {
+    // Test regression: pixel array smaller than width * height should throw IllegalArgumentException
+    int width = 3;
+    int height = 3;
+    int[] pixels = new int[width * height - 1]; // One pixel short
+    new RGBLuminanceSource(width, height, pixels);
+  }
+
+}


### PR DESCRIPTION
Adds a new class `GrayscaleLuminanceSource`, which is like `RGBLuminanceSource`, but is for grayscale pixel data instead of ARGB pixel data.

`RGBLuminanceSource` was already converting RGB data to grayscale data in the constructor, and then operating exclusively on grayscale data internally. This change moves all of the internal `RGBLuminanceSource` logic as-is into `GrayscaleLuminanceSource`, adds a grayscale pixel constructor, and leaves only the RGB -> grayscale conversion in `RGBLuminanceSource`.

The new test class `GrayscaleLuminanceSourceTestCase` is a copy of `RGBLuminanceSourceTestCase` but with the `SOURCE` constant values adjusted to reflect the equivalent grayscale values.