### PR TITLE
fix: add missing `ERRORS_CORRECTED` metadata in QRCodeMultiReader

### DIFF
--- a/core/src/main/java/com/google/zxing/multi/qrcode/QRCodeMultiReader.java
+++ b/core/src/main/java/com/google/zxing/multi/qrcode/QRCodeMultiReader.java
@@ -83,6 +83,7 @@ public final class QRCodeMultiReader extends QRCodeReader implements MultipleBar
           result.putMetadata(ResultMetadataType.STRUCTURED_APPEND_PARITY,
                              decoderResult.getStructuredAppendParity());
         }
+        result.putMetadata(ResultMetadataType.ERRORS_CORRECTED, decoderResult.getErrorsCorrected());
         // Fix SYMBOLOGY_IDENTIFIER loss in QRCodeMultiReader
         result.putMetadata(ResultMetadataType.SYMBOLOGY_IDENTIFIER, "]Q" + decoderResult.getSymbologyModifier());
 


### PR DESCRIPTION
Hi, thank you for maintaining this project for such a long time!
I found what appears to be a missing implementation and have fixed it. I would appreciate it if you could merge this.

# about

It seems that the error correction count addition, which is implemented in [`QRCodeReader.java`](https://github.com/zxing/zxing/blob/50799640d5c4d6cd85f75f047a3055d05485fae5/core/src/main/java/com/google/zxing/qrcode/QRCodeReader.java#L102), was overlooked in `QRCodeMultiReader.java`.
This fix ensures that both decoders return the consistent metadata.

# see also
Related PR(?)
- #1657 