### PR TITLE
Fix filling in of stack traces during testing

### DIFF
--- a/core/src/main/java/com/google/zxing/ReaderException.java
+++ b/core/src/main/java/com/google/zxing/ReaderException.java
@@ -38,10 +38,13 @@ public abstract class ReaderException extends Exception {
     super(cause);
   }
 
-  // Prevent stack traces from being taken
   @Override
   public final synchronized Throwable fillInStackTrace() {
-    return null;
+    if (isStackTrace) {
+      return super.fillInStackTrace();
+    } else {
+      return this; // prevent stack traces from being taken
+    }
   }
 
   /**


### PR DESCRIPTION
Stack traces were not being filled in for exceptions thrown during testing, because the `fillInStackTrace` method override was preventing it regardless of the `isStackTrace` setting.