### PR TITLE
Avoid charset provider lookups for UTF-8 QR encoding

### DIFF
--- a/core/src/main/java/com/google/zxing/common/CharacterSetECI.java
+++ b/core/src/main/java/com/google/zxing/common/CharacterSetECI.java
@@ -20,7 +20,6 @@ import com.google.zxing.FormatException;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,7 +33,7 @@ public enum CharacterSetECI {
 
   // Enum name is a Java encoding valid for java.lang and java.io
   Cp437(new int[]{0,2}),
-  ISO8859_1(new int[]{1,3}, "ISO-8859-1"),
+  ISO8859_1(new int[]{1,3}, StandardCharsets.ISO_8859_1, "ISO-8859-1"),
   ISO8859_2(4, "ISO-8859-2"),
   ISO8859_3(5, "ISO-8859-3"),
   ISO8859_4(6, "ISO-8859-4"),
@@ -54,30 +53,29 @@ public enum CharacterSetECI {
   Cp1251(22, "windows-1251"),
   Cp1252(23, "windows-1252"),
   Cp1256(24, "windows-1256"),
-  UnicodeBigUnmarked(25, "UTF-16BE", "UnicodeBig"),
-  UTF8(26, "UTF-8"),
-  ASCII(new int[] {27, 170}, "US-ASCII"),
+  UnicodeBigUnmarked(25, StandardCharsets.UTF_16BE, "UTF-16BE", "UnicodeBig"),
+  UTF8(26, StandardCharsets.UTF_8, "UTF-8"),
+  ASCII(new int[] {27, 170}, StandardCharsets.US_ASCII, "US-ASCII"),
   Big5(28),
   GB18030(29, "GB2312", "EUC_CN", "GBK"),
   EUC_KR(30, "EUC-KR");
 
-  private static final class Maps {
-    private static final Map<Integer,CharacterSetECI> VALUE_TO_ECI = new HashMap<>();
-    private static final Map<String,CharacterSetECI> NAME_TO_ECI = new HashMap<>();
-    static {
-      for (CharacterSetECI eci : values()) {
-        for (int value : eci.values) {
-          VALUE_TO_ECI.put(value, eci);
-        }
-        NAME_TO_ECI.put(eci.name(), eci);
-        for (String name : eci.otherEncodingNames) {
-          NAME_TO_ECI.put(name, eci);
-        }
+  private static final Map<Integer,CharacterSetECI> VALUE_TO_ECI = new HashMap<>();
+  private static final Map<String,CharacterSetECI> NAME_TO_ECI = new HashMap<>();
+  static {
+    for (CharacterSetECI eci : values()) {
+      for (int value : eci.values) {
+        VALUE_TO_ECI.put(value, eci);
+      }
+      NAME_TO_ECI.put(eci.name(), eci);
+      for (String name : eci.otherEncodingNames) {
+        NAME_TO_ECI.put(name, eci);
       }
     }
   }
 
   private final int[] values;
+  private final Charset standardCharset;
   private final String[] otherEncodingNames;
 
   CharacterSetECI(int value) {
@@ -85,12 +83,20 @@ public enum CharacterSetECI {
   }
 
   CharacterSetECI(int value, String... otherEncodingNames) {
-    this.values = new int[] {value};
-    this.otherEncodingNames = otherEncodingNames;
+    this(new int[] {value}, null, otherEncodingNames);
+  }
+
+  CharacterSetECI(int value, Charset standardCharset, String... otherEncodingNames) {
+    this(new int[] {value}, standardCharset, otherEncodingNames);
   }
 
   CharacterSetECI(int[] values, String... otherEncodingNames) {
+    this(values, null, otherEncodingNames);
+  }
+
+  CharacterSetECI(int[] values, Charset standardCharset, String... otherEncodingNames) {
     this.values = values;
+    this.standardCharset = standardCharset;
     this.otherEncodingNames = otherEncodingNames;
   }
 
@@ -99,34 +105,14 @@ public enum CharacterSetECI {
   }
 
   public Charset getCharset() {
-    Charset charset = getPrimaryCharsetOrNull();
-    if (charset != null) {
-      return charset;
+    if (standardCharset != null) {
+      return standardCharset;
     }
-    throw new UnsupportedCharsetException(name());
-  }
-
-  private Charset getPrimaryCharsetOrNull() {
-    switch (this) {
-      case ISO8859_1:
-        return StandardCharsets.ISO_8859_1;
-      case UTF8:
-        return StandardCharsets.UTF_8;
-      case ASCII:
-        return StandardCharsets.US_ASCII;
-      case UnicodeBigUnmarked:
-        return StandardCharsets.UTF_16BE;
-      default:
-    }
-    try {
-      return Charset.forName(name());
-    } catch (UnsupportedCharsetException uce) {
-      return null;
-    }
+    return Charset.forName(name());
   }
 
   private boolean isCharsetSupported() {
-    return getPrimaryCharsetOrNull() != null;
+    return standardCharset != null || Charset.isSupported(name());
   }
 
   /**
@@ -135,7 +121,7 @@ public enum CharacterSetECI {
    *   but unsupported
    */
   public static CharacterSetECI getCharacterSetECI(Charset charset) {
-    CharacterSetECI eci = Maps.NAME_TO_ECI.get(charset.name());
+    CharacterSetECI eci = NAME_TO_ECI.get(charset.name());
     return eci == null || eci.isCharsetSupported() ? eci : null;
   }
 
@@ -149,7 +135,7 @@ public enum CharacterSetECI {
     if (value < 0 || value >= 900) {
       throw FormatException.getFormatInstance();
     }
-    CharacterSetECI eci = Maps.VALUE_TO_ECI.get(value);
+    CharacterSetECI eci = VALUE_TO_ECI.get(value);
     return eci == null || eci.isCharsetSupported() ? eci : null;
   }
 
@@ -159,7 +145,7 @@ public enum CharacterSetECI {
    *   but unsupported
    */
   public static CharacterSetECI getCharacterSetECIByName(String name) {
-    CharacterSetECI eci = Maps.NAME_TO_ECI.get(name);
+    CharacterSetECI eci = NAME_TO_ECI.get(name);
     return eci == null || eci.isCharsetSupported() ? eci : null;
   }
 

--- a/core/src/main/java/com/google/zxing/common/CharacterSetECI.java
+++ b/core/src/main/java/com/google/zxing/common/CharacterSetECI.java
@@ -19,7 +19,8 @@ package com.google.zxing.common;
 import com.google.zxing.FormatException;
 
 import java.nio.charset.Charset;
-
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,12 +61,11 @@ public enum CharacterSetECI {
   GB18030(29, "GB2312", "EUC_CN", "GBK"),
   EUC_KR(30, "EUC-KR");
 
-  // only character sets supported by the current JVM are registered here
-  private static final Map<Integer,CharacterSetECI> VALUE_TO_ECI = new HashMap<>();
-  private static final Map<String,CharacterSetECI> NAME_TO_ECI = new HashMap<>();
-  static {
-    for (CharacterSetECI eci : values()) {
-      if (Charset.isSupported(eci.name())) {
+  private static final class Maps {
+    private static final Map<Integer,CharacterSetECI> VALUE_TO_ECI = new HashMap<>();
+    private static final Map<String,CharacterSetECI> NAME_TO_ECI = new HashMap<>();
+    static {
+      for (CharacterSetECI eci : values()) {
         for (int value : eci.values) {
           VALUE_TO_ECI.put(value, eci);
         }
@@ -99,7 +99,34 @@ public enum CharacterSetECI {
   }
 
   public Charset getCharset() {
-    return Charset.forName(name());
+    Charset charset = getPrimaryCharsetOrNull();
+    if (charset != null) {
+      return charset;
+    }
+    throw new UnsupportedCharsetException(name());
+  }
+
+  private Charset getPrimaryCharsetOrNull() {
+    switch (this) {
+      case ISO8859_1:
+        return StandardCharsets.ISO_8859_1;
+      case UTF8:
+        return StandardCharsets.UTF_8;
+      case ASCII:
+        return StandardCharsets.US_ASCII;
+      case UnicodeBigUnmarked:
+        return StandardCharsets.UTF_16BE;
+      default:
+    }
+    try {
+      return Charset.forName(name());
+    } catch (UnsupportedCharsetException uce) {
+      return null;
+    }
+  }
+
+  private boolean isCharsetSupported() {
+    return getPrimaryCharsetOrNull() != null;
   }
 
   /**
@@ -108,7 +135,8 @@ public enum CharacterSetECI {
    *   but unsupported
    */
   public static CharacterSetECI getCharacterSetECI(Charset charset) {
-    return NAME_TO_ECI.get(charset.name());
+    CharacterSetECI eci = Maps.NAME_TO_ECI.get(charset.name());
+    return eci == null || eci.isCharsetSupported() ? eci : null;
   }
 
   /**
@@ -121,7 +149,8 @@ public enum CharacterSetECI {
     if (value < 0 || value >= 900) {
       throw FormatException.getFormatInstance();
     }
-    return VALUE_TO_ECI.get(value);
+    CharacterSetECI eci = Maps.VALUE_TO_ECI.get(value);
+    return eci == null || eci.isCharsetSupported() ? eci : null;
   }
 
   /**
@@ -130,7 +159,8 @@ public enum CharacterSetECI {
    *   but unsupported
    */
   public static CharacterSetECI getCharacterSetECIByName(String name) {
-    return NAME_TO_ECI.get(name);
+    CharacterSetECI eci = Maps.NAME_TO_ECI.get(name);
+    return eci == null || eci.isCharsetSupported() ? eci : null;
   }
 
 }

--- a/core/src/main/java/com/google/zxing/qrcode/encoder/Encoder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/encoder/Encoder.java
@@ -19,8 +19,8 @@ package com.google.zxing.qrcode.encoder;
 import com.google.zxing.EncodeHintType;
 import com.google.zxing.WriterException;
 import com.google.zxing.common.BitArray;
-import com.google.zxing.common.StringUtils;
 import com.google.zxing.common.CharacterSetECI;
+import com.google.zxing.common.StringUtils;
 import com.google.zxing.common.reedsolomon.GenericGF;
 import com.google.zxing.common.reedsolomon.ReedSolomonEncoder;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
@@ -249,7 +249,8 @@ public final class Encoder {
    * if it is Shift_JIS, and the input is only double-byte Kanji, then we return {@link Mode#KANJI}.
    */
   private static Mode chooseMode(String content, Charset encoding) {
-    if (StringUtils.SHIFT_JIS_CHARSET != null &&
+    if (isShiftJIS(encoding) &&
+        StringUtils.SHIFT_JIS_CHARSET != null &&
         StringUtils.SHIFT_JIS_CHARSET.equals(encoding) &&
         isOnlyDoubleByteKanji(content)) {
       // Choose Kanji mode if all input are double-byte characters
@@ -274,6 +275,11 @@ public final class Encoder {
       return Mode.NUMERIC;
     }
     return Mode.BYTE;
+  }
+
+  private static boolean isShiftJIS(Charset encoding) {
+    return encoding != null &&
+        ("Shift_JIS".equalsIgnoreCase(encoding.name()) || "SJIS".equalsIgnoreCase(encoding.name()));
   }
 
   static boolean isOnlyDoubleByteKanji(String content) {

--- a/core/src/main/java/com/google/zxing/qrcode/encoder/Encoder.java
+++ b/core/src/main/java/com/google/zxing/qrcode/encoder/Encoder.java
@@ -249,7 +249,8 @@ public final class Encoder {
    * if it is Shift_JIS, and the input is only double-byte Kanji, then we return {@link Mode#KANJI}.
    */
   private static Mode chooseMode(String content, Charset encoding) {
-    if (isShiftJIS(encoding) &&
+    if (encoding != null &&
+        ("Shift_JIS".equalsIgnoreCase(encoding.name()) || "SJIS".equalsIgnoreCase(encoding.name())) &&
         StringUtils.SHIFT_JIS_CHARSET != null &&
         StringUtils.SHIFT_JIS_CHARSET.equals(encoding) &&
         isOnlyDoubleByteKanji(content)) {
@@ -275,11 +276,6 @@ public final class Encoder {
       return Mode.NUMERIC;
     }
     return Mode.BYTE;
-  }
-
-  private static boolean isShiftJIS(Charset encoding) {
-    return encoding != null &&
-        ("Shift_JIS".equalsIgnoreCase(encoding.name()) || "SJIS".equalsIgnoreCase(encoding.name()));
   }
 
   static boolean isOnlyDoubleByteKanji(String content) {

--- a/core/src/test/java/com/google/zxing/common/CharacterSetECITestCase.java
+++ b/core/src/test/java/com/google/zxing/common/CharacterSetECITestCase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 ZXing authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zxing.common;
+
+import com.google.zxing.FormatException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Tests {@link CharacterSetECI}.
+ */
+public final class CharacterSetECITestCase extends Assert {
+
+  @Test
+  public void testStandardCharsets() throws FormatException {
+    assertSame(CharacterSetECI.ISO8859_1, CharacterSetECI.getCharacterSetECI(StandardCharsets.ISO_8859_1));
+    assertSame(CharacterSetECI.ISO8859_1, CharacterSetECI.getCharacterSetECIByName("ISO-8859-1"));
+    assertSame(CharacterSetECI.ISO8859_1, CharacterSetECI.getCharacterSetECIByValue(1));
+    assertSame(StandardCharsets.ISO_8859_1, CharacterSetECI.ISO8859_1.getCharset());
+
+    assertSame(CharacterSetECI.UTF8, CharacterSetECI.getCharacterSetECI(StandardCharsets.UTF_8));
+    assertSame(CharacterSetECI.UTF8, CharacterSetECI.getCharacterSetECIByName("UTF-8"));
+    assertSame(CharacterSetECI.UTF8, CharacterSetECI.getCharacterSetECIByValue(26));
+    assertSame(StandardCharsets.UTF_8, CharacterSetECI.UTF8.getCharset());
+
+    assertSame(CharacterSetECI.ASCII, CharacterSetECI.getCharacterSetECI(StandardCharsets.US_ASCII));
+    assertSame(CharacterSetECI.ASCII, CharacterSetECI.getCharacterSetECIByName("US-ASCII"));
+    assertSame(CharacterSetECI.ASCII, CharacterSetECI.getCharacterSetECIByValue(27));
+    assertSame(StandardCharsets.US_ASCII, CharacterSetECI.ASCII.getCharset());
+
+    assertSame(CharacterSetECI.UnicodeBigUnmarked,
+               CharacterSetECI.getCharacterSetECI(StandardCharsets.UTF_16BE));
+    assertSame(CharacterSetECI.UnicodeBigUnmarked, CharacterSetECI.getCharacterSetECIByName("UTF-16BE"));
+    assertSame(CharacterSetECI.UnicodeBigUnmarked, CharacterSetECI.getCharacterSetECIByValue(25));
+    assertSame(StandardCharsets.UTF_16BE, CharacterSetECI.UnicodeBigUnmarked.getCharset());
+  }
+
+  @Test
+  public void testGB18030UsesPrimaryCharset() throws FormatException {
+    if (Charset.isSupported("GB18030")) {
+      assertSame(CharacterSetECI.GB18030, CharacterSetECI.getCharacterSetECIByName("GBK"));
+      assertSame(CharacterSetECI.GB18030, CharacterSetECI.getCharacterSetECIByValue(29));
+      assertEquals(Charset.forName("GB18030"), CharacterSetECI.GB18030.getCharset());
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #2076.

## Summary

This avoids unnecessary charset-provider lookups when encoding QR codes with standard character set hints such as UTF-8.

The UTF-8 QR path can currently initialize charset lookup machinery that probes optional charset providers. On Android this can perform disk I/O, which is visible to StrictMode when QR codes are encoded on the main thread.

This change:

- Lazily initializes `CharacterSetECI` lookup maps instead of probing `Charset` support during enum class initialization.
- Uses `StandardCharsets` for guaranteed standard ECI charsets, including UTF-8.
- Keeps ECI support checks tied to the primary ECI charset, so aliases do not make an unsupported ECI appear decodable.
- Avoids touching `StringUtils.SHIFT_JIS_CHARSET` during QR mode selection unless the requested charset is Shift_JIS-like.

## Validation

- `mvn -pl core -Dtest=CharacterSetECITestCase,EncoderTestCase,DecodedBitStreamParserTestCase test`
- `mvn -pl core test`
- `git diff --check`
