### PR TITLE
avoid out-of-bounds read in pdf417 decodeMacroBlock

### DIFF
--- a/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
@@ -159,7 +159,8 @@ final class DecodedBitStreamParser {
   @SuppressWarnings("deprecation")
   static int decodeMacroBlock(int[] codewords, int codeIndex, PDF417ResultMetadata resultMetadata)
       throws FormatException {
-    if (codeIndex + NUMBER_OF_SEQUENCE_CODEWORDS > codewords[0]) {
+    int maxLength = codewords[0];
+    if (codeIndex + NUMBER_OF_SEQUENCE_CODEWORDS > maxLength) {
       // we must have at least two bytes left for the segment index
       throw FormatException.getFormatInstance();
     }
@@ -183,7 +184,7 @@ final class DecodedBitStreamParser {
     // (See ISO/IEC 15438:2015 Annex H.6) and preserves all info, but some generators (e.g. TEC-IT) write
     // the fileId using text compaction, so in those cases the fileId will appear mangled.
     StringBuilder fileId = new StringBuilder();
-    while (codeIndex < codewords[0] &&
+    while (codeIndex < maxLength &&
            codeIndex < codewords.length &&
            codewords[codeIndex] != MACRO_PDF417_TERMINATOR &&
            codewords[codeIndex] != BEGIN_MACRO_PDF417_OPTIONAL_FIELD) {
@@ -197,15 +198,15 @@ final class DecodedBitStreamParser {
     resultMetadata.setFileId(fileId.toString());
 
     int optionalFieldsStart = -1;
-    if (codeIndex < codewords[0] && codewords[codeIndex] == BEGIN_MACRO_PDF417_OPTIONAL_FIELD) {
+    if (codeIndex < maxLength && codewords[codeIndex] == BEGIN_MACRO_PDF417_OPTIONAL_FIELD) {
       optionalFieldsStart = codeIndex + 1;
     }
 
-    while (codeIndex < codewords[0]) {
+    while (codeIndex < maxLength) {
       switch (codewords[codeIndex]) {
         case BEGIN_MACRO_PDF417_OPTIONAL_FIELD:
           codeIndex++;
-          if (codeIndex >= codewords[0]) {
+          if (codeIndex >= maxLength) {
             throw FormatException.getFormatInstance();
           }
           switch (codewords[codeIndex]) {

--- a/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
@@ -197,7 +197,7 @@ final class DecodedBitStreamParser {
     resultMetadata.setFileId(fileId.toString());
 
     int optionalFieldsStart = -1;
-    if (codewords[codeIndex] == BEGIN_MACRO_PDF417_OPTIONAL_FIELD) {
+    if (codeIndex < codewords[0] && codewords[codeIndex] == BEGIN_MACRO_PDF417_OPTIONAL_FIELD) {
       optionalFieldsStart = codeIndex + 1;
     }
 
@@ -205,6 +205,9 @@ final class DecodedBitStreamParser {
       switch (codewords[codeIndex]) {
         case BEGIN_MACRO_PDF417_OPTIONAL_FIELD:
           codeIndex++;
+          if (codeIndex >= codewords[0]) {
+            throw FormatException.getFormatInstance();
+          }
           switch (codewords[codeIndex]) {
             case MACRO_PDF417_OPTIONAL_FIELD_FILE_NAME:
               ECIStringBuilder fileName = new ECIStringBuilder();


### PR DESCRIPTION
ArrayIndexOutOfBoundsException escaping decode() when a macro block sits in the final codeword positions:

    java.lang.ArrayIndexOutOfBoundsException: Index 7 out of bounds for length 7
        at DecodedBitStreamParser.decodeMacroBlock

decodeMacroBlock probes for the optional-fields marker and reads the field type after BEGIN_MACRO_PDF417_OPTIONAL_FIELD without checking codeIndex against codewords[0]; the decoder tests mask this by padding arrays with a trailing dummy codeword.
