### PR TITLE
guard base256 length read in datamatrix decodeBase256Segment

### DIFF
--- a/core/src/main/java/com/google/zxing/datamatrix/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/decoder/DecodedBitStreamParser.java
@@ -530,6 +530,9 @@ final class DecodedBitStreamParser {
     } else if (d1 < 250) {
       count = d1;
     } else {
+      if (bits.available() < 8) {
+        throw FormatException.getFormatInstance();
+      }
       count = 250 * (d1 - 249) + unrandomize255State(bits.readBits(8), codewordPosition++);
     }
 

--- a/core/src/test/java/com/google/zxing/datamatrix/decoder/DecodedBitStreamParserTestCase.java
+++ b/core/src/test/java/com/google/zxing/datamatrix/decoder/DecodedBitStreamParserTestCase.java
@@ -16,6 +16,7 @@
 
 package com.google.zxing.datamatrix.decoder;
 
+import com.google.zxing.FormatException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,6 +43,14 @@ public final class DecodedBitStreamParserTestCase extends Assert {
     assertEquals("00019899", decodedString);
   }
   
+  @Test(expected = FormatException.class)
+  public void testBase256TruncatedLongLength() throws Exception {
+    // 231 latches to Base 256. The next byte unrandomizes to 250 at codeword position 2,
+    // which signals a multi-byte length, but no further byte is present to read.
+    byte[] bytes = {(byte) 231, (byte) 38};
+    DecodedBitStreamParser.decode(bytes);
+  }
+
   // TODO(bbrown): Add test cases for each encoding type
   // TODO(bbrown): Add test cases for switching encoding types
 }


### PR DESCRIPTION
In decodeBase256Segment a length codeword d1 of 250 or more signals a multi-byte length, so the code reads a second byte with bits.readBits(8) at DecodedBitStreamParser.java:533 without first checking one is available. A symbol that latches to Base 256 and ends on such a codeword (e.g. bytes 231, 38) throws IllegalArgumentException out of DataMatrixReader.decode, which should only throw ReaderException. Added the same available() check the method already uses for the per-byte reads.