### PR TITLE
avoid out-of-bounds reads after control codewords in pdf417 parser

### DIFF
--- a/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
@@ -115,12 +115,18 @@ final class DecodedBitStreamParser {
           codeIndex = byteCompaction(code, codewords, codeIndex, result);
           break;
         case MODE_SHIFT_TO_BYTE_COMPACTION_MODE:
+          if (codeIndex >= count) {
+            throw FormatException.getFormatInstance();
+          }
           result.append((char) codewords[codeIndex++]);
           break;
         case NUMERIC_COMPACTION_MODE_LATCH:
           codeIndex = numericCompaction(codewords, codeIndex, result);
           break;
         case ECI_CHARSET:
+          if (codeIndex >= count) {
+            throw FormatException.getFormatInstance();
+          }
           result.appendECI(codewords[codeIndex++]);
           break;
         case ECI_GENERAL_PURPOSE:
@@ -338,16 +344,19 @@ final class DecodedBitStreamParser {
             // of the Text Compaction mode. Codeword 913 is only available
             // in Text Compaction mode; its use is described in 5.4.2.4.
             textCompactionData[index] = MODE_SHIFT_TO_BYTE_COMPACTION_MODE;
+            if (codeIndex >= codewords[0]) {
+              throw FormatException.getFormatInstance();
+            }
             code = codewords[codeIndex++];
             byteCompactionData[index] = code;
             index++;
             break;
           case ECI_CHARSET:
-            subMode = decodeTextCompaction(textCompactionData, byteCompactionData, index, result, subMode);
-            result.appendECI(codewords[codeIndex++]);
-            if (codeIndex > codewords[0]) {
+            if (codeIndex >= codewords[0]) {
               throw FormatException.getFormatInstance();
             }
+            subMode = decodeTextCompaction(textCompactionData, byteCompactionData, index, result, subMode);
+            result.appendECI(codewords[codeIndex++]);
             textCompactionData = new int[(codewords[0] - codeIndex) * 2];
             byteCompactionData = new int[(codewords[0] - codeIndex) * 2];
             index = 0;
@@ -580,6 +589,9 @@ final class DecodedBitStreamParser {
     while (codeIndex < codewords[0] && !end) {
       //handle leading ECIs
       while (codeIndex < codewords[0] && codewords[codeIndex] == ECI_CHARSET) {
+        if (codeIndex + 1 >= codewords[0]) {
+          throw FormatException.getFormatInstance();
+        }
         result.appendECI(codewords[++codeIndex]);
         codeIndex++;
       }
@@ -609,6 +621,9 @@ final class DecodedBitStreamParser {
             if (code < TEXT_COMPACTION_MODE_LATCH) {
               result.append((byte) code);
             } else if (code == ECI_CHARSET) {
+              if (codeIndex >= codewords[0]) {
+                throw FormatException.getFormatInstance();
+              }
               result.appendECI(codewords[codeIndex++]);
             } else {
               codeIndex--;

--- a/core/src/test/java/com/google/zxing/pdf417/decoder/PDF417DecoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/decoder/PDF417DecoderTestCase.java
@@ -182,6 +182,38 @@ public class PDF417DecoderTestCase extends Assert {
     DecodedBitStreamParser.decode(sampleCodes, "0");
   }
 
+  @Test(expected = FormatException.class)
+  public void testTextCompactionModeShiftAtEnd() throws FormatException {
+    // mode shift to byte compaction (913) as the final codeword, no value follows
+    DecodedBitStreamParser.decode(new int[] {3, 65, 913}, "0");
+  }
+
+  @Test(expected = FormatException.class)
+  public void testTextCompactionEciAtEnd() throws FormatException {
+    // ECI charset marker (927) as the final codeword, no charset value follows
+    DecodedBitStreamParser.decode(new int[] {3, 65, 927}, "0");
+  }
+
+  @Test(expected = FormatException.class)
+  public void testByteCompactionLeadingEciAtEnd() throws FormatException {
+    DecodedBitStreamParser.decode(new int[] {3, 901, 927}, "0");
+  }
+
+  @Test(expected = FormatException.class)
+  public void testByteCompactionEciAtEnd() throws FormatException {
+    DecodedBitStreamParser.decode(new int[] {5, 901, 65, 66, 927}, "0");
+  }
+
+  @Test(expected = FormatException.class)
+  public void testModeShiftToByteAtEnd() throws FormatException {
+    DecodedBitStreamParser.decode(new int[] {4, 901, 65, 913}, "0");
+  }
+
+  @Test(expected = FormatException.class)
+  public void testEciCharsetAtEnd() throws FormatException {
+    DecodedBitStreamParser.decode(new int[] {5, 902, 1, 200, 927}, "0");
+  }
+
   @Test
   public void testUppercase() throws WriterException, FormatException {
     //encodeDecode("", 0);


### PR DESCRIPTION
Several spots in the pdf417 parser read the codeword right after a control codeword without checking another one is there:
- decode: the byte value after a 913 mode shift, and the charset value after a 927 ECI
- textCompaction: same 913 and 927 cases
- byteCompaction: the leading-ECI loop and the fallback-ECI read

When the marker is the last data codeword and codewords[0] equals the array length (which verifyCodewordCount allows, and the existing decode tests rely on), the read runs one past the end and throws ArrayIndexOutOfBoundsException out of PDF417Reader.decode, which is only supposed to throw ReaderException. Guarded each so a missing trailing codeword throws FormatException, same as decodeMacroBlock already does.