### PR TITLE
guard unterminated AI in ExpandedProductResultParser

### DIFF
--- a/core/src/main/java/com/google/zxing/client/result/ExpandedProductResultParser.java
+++ b/core/src/main/java/com/google/zxing/client/result/ExpandedProductResultParser.java
@@ -192,7 +192,8 @@ public final class ExpandedProductResultParser extends ResultParser {
       }
       buf.append(currentChar);
     }
-    return buf.toString();
+    // no closing parenthesis, so this is not a valid AI
+    return null;
   }
 
   private static String findValue(int i, String rawText) {

--- a/core/src/test/java/com/google/zxing/client/result/ExpandedProductParsedResultTestCase.java
+++ b/core/src/test/java/com/google/zxing/client/result/ExpandedProductParsedResultTestCase.java
@@ -63,4 +63,14 @@ public final class ExpandedProductParsedResultTestCase extends Assert {
     assertEquals("445", o.getPriceCurrency());
     assertEquals(uncommonAIs, o.getUncommonAIs());
   }
+
+  @Test
+  public void testUnterminatedAI() {
+    // an AI that is not closed by ')' must not match, rather than read past the end of the text
+    ExpandedProductResultParser parser = new ExpandedProductResultParser();
+    assertNull(parser.parse(new Result("(99", null, null, BarcodeFormat.RSS_EXPANDED)));
+    assertNull(parser.parse(new Result("(", null, null, BarcodeFormat.RSS_EXPANDED)));
+    // a valid prefix followed by a truncated final AI must parse without throwing
+    assertNotNull(parser.parse(new Result("(01)66546(13)001205(3932", null, null, BarcodeFormat.RSS_EXPANDED)));
+  }
 }


### PR DESCRIPTION
treat an unterminated AI (no closing ')') as no match in findAIvalue, otherwise the (ai)value loop in parse advances past the end of the text and findValue calls substring out of range, throwing StringIndexOutOfBoundsException out of ResultParser.parseResult instead of returning null for malformed RSS Expanded input.