### PR TITLE
guard truncated symbol in rss expanded AI01AndOtherAIs decoder

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/rss/expanded/decoders/AI01AndOtherAIs.java
+++ b/core/src/main/java/com/google/zxing/oned/rss/expanded/decoders/AI01AndOtherAIs.java
@@ -44,6 +44,10 @@ final class AI01AndOtherAIs extends AI01decoder {
 
   @Override
   public String parseInformation() throws NotFoundException, FormatException {
+    if (this.getInformation().getSize() < HEADER_SIZE + GTIN_SIZE + 4) {
+      throw NotFoundException.getNotFoundInstance();
+    }
+
     StringBuilder buff = new StringBuilder();
 
     buff.append("(01)");

--- a/core/src/test/java/com/google/zxing/oned/rss/expanded/decoders/AI01AndOtherAIsTest.java
+++ b/core/src/test/java/com/google/zxing/oned/rss/expanded/decoders/AI01AndOtherAIsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2010 ZXing authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zxing.oned.rss.expanded.decoders;
+
+import com.google.zxing.NotFoundException;
+import com.google.zxing.common.BitArray;
+import com.google.zxing.oned.rss.expanded.BinaryUtil;
+
+import org.junit.Test;
+
+/**
+ * @author Pablo Orduña, University of Deusto (pablo.orduna@deusto.es)
+ */
+public final class AI01AndOtherAIsTest extends AbstractDecoderTest {
+
+  // first bit is the linkage flag, second bit selects this decoder
+  @Test(expected = NotFoundException.class)
+  public void testTruncatedSymbol() throws Exception {
+    // 24 bits, too few to hold the compressed GTIN this decoder always reads
+    BitArray binary = BinaryUtil.buildBitArrayFromStringWithoutSpaces(".X......................");
+    AbstractExpandedDecoder.createDecoder(binary).parseInformation();
+  }
+}


### PR DESCRIPTION
- `AI01AndOtherAIs.parseInformation` reads the fixed 48-bit compressed GTIN without first checking the symbol is long enough, unlike the sibling AI decoders which all validate size up front
- a short RSS Expanded symbol whose second bit is set selects this decoder, and `extractNumericValueFromBitArray` then reads past the backing `BitArray` and throws `ArrayIndexOutOfBoundsException`, which escapes `RSSExpandedReader.decodeRow`
- added the same minimum-size guard the siblings use, so a truncated symbol throws `NotFoundException`
