### PR TITLE
avoid NegativeArraySizeException in aztec getEncodedData

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -108,7 +108,7 @@ public final class Decoder {
 
     // Final decoded string result
     // (correctedBits-5) / 4 is an upper bound on the size (all-digit result)
-    StringBuilder result = new StringBuilder((correctedBits.length - 5) / 4);
+    StringBuilder result = new StringBuilder(Math.max(0, (correctedBits.length - 5) / 4));
 
     // Intermediary buffer of decoded bytes, which is decoded into a string and flushed
     // when character encoding changes (ECI) or input ends.

--- a/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
@@ -64,6 +64,13 @@ public final class DecoderTest extends Assert {
   }
 
   @Test
+  public void testHighLevelDecodeShortInput() throws FormatException {
+    // fewer than 5 corrected bits decode to nothing and must not throw NegativeArraySizeException
+    assertEquals("", Decoder.highLevelDecode(new boolean[0]));
+    assertEquals("", Decoder.highLevelDecode(new boolean[1]));
+  }
+
+  @Test
   public void testAztecResult() throws FormatException {
     BitMatrix matrix = BitMatrix.parse(
         "X X X X X     X X X       X X X     X X X     \n" +


### PR DESCRIPTION
getEncodedData sizes its result builder as (correctedBits.length - 5) / 4:
- that value is negative for inputs under 5 bits, so new StringBuilder throws NegativeArraySizeException
- highLevelDecode(boolean[]) is the public entry that reaches it, and it declares only FormatException
- such short input otherwise decodes to an empty string, the loop produces nothing
Clamped the capacity to a non-negative value, same shape as the base 256 length guard in the Data Matrix decoder.