### PR TITLE
guard empty symbol in code39 check digit handling

### DIFF
--- a/core/src/main/java/com/google/zxing/oned/Code39Reader.java
+++ b/core/src/main/java/com/google/zxing/oned/Code39Reader.java
@@ -141,6 +141,10 @@ public final class Code39Reader extends OneDReader {
     }
 
     if (usingCheckDigit) {
+      if (result.length() == 0) {
+        // false positive -- a symbol with no payload cannot carry a check digit
+        throw NotFoundException.getNotFoundInstance();
+      }
       int max = result.length() - 1;
       int total = 0;
       for (int i = 0; i < max; i++) {

--- a/core/src/test/java/com/google/zxing/oned/Code39ExtendedModeTestCase.java
+++ b/core/src/test/java/com/google/zxing/oned/Code39ExtendedModeTestCase.java
@@ -64,6 +64,24 @@ public final class Code39ExtendedModeTestCase extends Assert {
     }
   }
 
+  @Test
+  public void testRejectsEmptySymbolWithCheckDigit() throws FormatException, ChecksumException {
+    // The asterisk (0x094) start/stop pattern as wide/narrow modules. A symbol that is just the
+    // start and stop asterisks decodes to an empty payload, so there is no character to validate
+    // as a check digit. It must fail with a ReaderException, not read result.charAt(-1).
+    String asterisk = "100101101101";
+    BitMatrix matrix = BitMatrix.parse("0000" + asterisk + '0' + asterisk + "0000", "1", "0");
+    BitArray row = new BitArray(matrix.getWidth());
+    matrix.getRow(0, row);
+    Code39Reader sut = new Code39Reader(true, false);
+    try {
+      sut.decodeRow(0, row, null);
+      fail("Expected NotFoundException for empty check-digit symbol");
+    } catch (NotFoundException expected) {
+      // expected
+    }
+  }
+
   private static void doTest(String expectedResult, String encodedResult)
       throws FormatException, ChecksumException, NotFoundException {
     Code39Reader sut = new Code39Reader(false, true);


### PR DESCRIPTION
Code39Reader.decodeRow with usingCheckDigit reads the last character as the check digit without first checking the buffer is non-empty:
- a symbol of just the start and stop asterisks decodes to an empty payload once the asterisk is removed
- max becomes -1 and result.charAt(max) throws StringIndexOutOfBoundsException out of decodeRow, which only declares ReaderException
- the existing empty-result check runs after the check digit block, too late to help
Throw NotFoundException for the empty case before the read, like Code93Reader does before validating its checksums.