### PR TITLE
reject non-square bit matrix in qrcode BitMatrixParser

### DIFF
--- a/core/src/main/java/com/google/zxing/qrcode/decoder/BitMatrixParser.java
+++ b/core/src/main/java/com/google/zxing/qrcode/decoder/BitMatrixParser.java
@@ -31,11 +31,11 @@ final class BitMatrixParser {
 
   /**
    * @param bitMatrix {@link BitMatrix} to parse
-   * @throws FormatException if dimension is not >= 21 and 1 mod 4
+   * @throws FormatException if dimension is not square, or not >= 21 and 1 mod 4
    */
   BitMatrixParser(BitMatrix bitMatrix) throws FormatException {
     int dimension = bitMatrix.getHeight();
-    if (dimension < 21 || (dimension & 0x03) != 1) {
+    if (dimension < 21 || (dimension & 0x03) != 1 || bitMatrix.getWidth() != dimension) {
       throw FormatException.getFormatInstance();
     }
     this.bitMatrix = bitMatrix;


### PR DESCRIPTION
BitMatrixParser validates only the matrix height, so a non-square QR matrix slips through:
- the constructor checks getHeight() is >= 21 and 1 mod 4, but never that width equals the height
- readCodewords then sweeps a dimension x dimension region (unmaskBitMatrix, get(j - col, i)) indexed by the height, so it runs off a narrower matrix
- the public Decoder.decode(boolean[][]) / decode(BitMatrix) then escape with ArrayIndexOutOfBoundsException instead of the documented FormatException, e.g. new Decoder().decode(new boolean[33][8])

Reject non-square input in the constructor, the same way the Data Matrix parser already validates both dimensions.