### PR TITLE
reject oversized received array in pdf417 ErrorCorrection.decode

### DIFF
--- a/core/src/main/java/com/google/zxing/pdf417/decoder/ec/ErrorCorrection.java
+++ b/core/src/main/java/com/google/zxing/pdf417/decoder/ec/ErrorCorrection.java
@@ -46,6 +46,12 @@ public final class ErrorCorrection {
                     int numECCodewords,
                     int[] erasures) throws ChecksumException {
 
+    if (received.length > field.getSize()) {
+      // A codeword cannot be longer than the field; otherwise erasure and error positions
+      // index past the exponent table in exp()/log().
+      throw ChecksumException.getChecksumInstance();
+    }
+
     ModulusPoly poly = new ModulusPoly(field, received);
     int[] S = new int[numECCodewords];
     boolean error = false;

--- a/core/src/test/java/com/google/zxing/pdf417/decoder/ec/ErrorCorrectionTestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/decoder/ec/ErrorCorrectionTestCase.java
@@ -84,6 +84,21 @@ public final class ErrorCorrectionTestCase extends AbstractErrorCorrectionTestCa
     }
   }
 
+  @Test
+  public void testOversizedReceived() {
+    // A received array longer than the field would index past the exponent table
+    // during erasure handling; it must be rejected instead of throwing AIOOBE.
+    int[] received = new int[ModulusGF.PDF417_GF.getSize() + 1];
+    System.arraycopy(PDF417_TEST_WITH_EC, 0, received, 0, PDF417_TEST_WITH_EC.length);
+    received[10] = (received[10] + 1) % ModulusGF.PDF417_GF.getSize(); // force a non-zero syndrome
+    try {
+      ec.decode(received, ECC_BYTES, new int[] {0});
+      fail("Should not have decoded");
+    } catch (ChecksumException ce) {
+      // good
+    }
+  }
+
   private void checkDecode(int[] received) throws ChecksumException {
     checkDecode(received, new int[0]);
   }


### PR DESCRIPTION
reject a received codeword vector longer than the galois field in ErrorCorrection.decode, otherwise an oversized pdf417 codeword grid (barcodeRowCount * barcodeColumnCount can reach 2700, well over the field size of 929) makes field.exp(received.length - 1 - erasure) index past the exponent table and throw ArrayIndexOutOfBoundsException out of PDF417Reader.decode.