### PR TITLE
fix catastrophic backtracking in email domain regex

### DIFF
--- a/core/src/main/java/com/google/zxing/client/result/EmailDoCoMoResultParser.java
+++ b/core/src/main/java/com/google/zxing/client/result/EmailDoCoMoResultParser.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 public final class EmailDoCoMoResultParser extends AbstractDoCoMoResultParser {
 
   private static final String EMAIL_LOCAL = "[^:]+";
-  private static final String EMAIL_DOMAIN = "([0-9a-zA-Z]+[0-9a-zA-Z\\-]+[0-9a-zA-Z]+\\.)+[a-zA-Z]{2,}";
+  private static final String EMAIL_DOMAIN = "([0-9a-zA-Z]+(-+[0-9a-zA-Z]+)*\\.)+[a-zA-Z]{2,}";
   private static final Pattern EMAIL = Pattern.compile("^" + EMAIL_LOCAL + "@" + EMAIL_DOMAIN + "$");
   
   @Override

--- a/core/src/test/java/com/google/zxing/client/result/EmailAddressParsedResultTestCase.java
+++ b/core/src/test/java/com/google/zxing/client/result/EmailAddressParsedResultTestCase.java
@@ -52,6 +52,17 @@ public final class EmailAddressParsedResultTestCase extends Assert {
     assertTrue(EmailDoCoMoResultParser.isBasicallyValidEmailAddress("建設省.aZ456@Ab-cd9Z.co"));
   }
 
+  // A long run of address characters that never completes a valid domain must be rejected
+  // quickly; the previous pattern backtracked super-linearly on such input.
+  @Test(timeout = 5000L)
+  public void testNoCatastrophicBacktracking() {
+    StringBuilder sb = new StringBuilder("x@");
+    for (int i = 0; i < 5000; i++) {
+      sb.append('a');
+    }
+    assertFalse(EmailDoCoMoResultParser.isBasicallyValidEmailAddress(sb.toString()));
+  }
+
   @Test
   public void testEmailAddress() {
     doTest("srowen@example.org", "srowen@example.org", null, null);


### PR DESCRIPTION
**ReDoS in email address validation**

`EmailDoCoMoResultParser.EMAIL_DOMAIN` matched each domain label with three adjacent overlapping quantifiers (`[0-9a-zA-Z]+[0-9a-zA-Z\-]+[0-9a-zA-Z]+`), so an address such as `x@` followed by a long run of letters with no terminating dot backtracks super-linearly. `isBasicallyValidEmailAddress` runs on the full decoded barcode text from both this parser and `EmailAddressResultParser` via `ResultParser.parseResult`, so a single crafted symbol reaches it.

On JDK 17, matching `x@` + 1000 letters takes ~1.1s and `x@` + 5000 letters ~117s; the rewritten label (alnum runs separated by hyphen runs) stays under ~10ms at 50k chars and keeps the existing accept/reject set in `EmailAddressParsedResultTestCase`.