### PR TITLE
format decoded digits locale-independently in maxicode/pdf417/aztec

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -30,6 +30,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * <p>The main class which implements Aztec Code decoding -- as opposed to locating and extracting
@@ -85,7 +86,7 @@ public final class Decoder {
     byte[] rawBytes = convertBoolArrayToByteArray(correctedBits.correctBits);
     String result = getEncodedData(correctedBits.correctBits);
     DecoderResult decoderResult =
-        new DecoderResult(rawBytes, result, null, String.format("%d%%", correctedBits.ecLevel));
+        new DecoderResult(rawBytes, result, null, String.format(Locale.ROOT, "%d%%", correctedBits.ecLevel));
     decoderResult.setNumBits(correctedBits.correctBits.length);
     decoderResult.setErrorsCorrected(correctedBits.errorsCorrected);
     return decoderResult;

--- a/core/src/main/java/com/google/zxing/maxicode/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/maxicode/decoder/DecodedBitStreamParser.java
@@ -19,7 +19,9 @@ package com.google.zxing.maxicode.decoder;
 import com.google.zxing.FormatException;
 import com.google.zxing.common.DecoderResult;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  * <p>MaxiCodes can encode text or structured information as bits in one of several modes,
@@ -96,12 +98,13 @@ final class DecodedBitStreamParser {
           if (ps2Length > 10) {
             throw FormatException.getFormatInstance();
           }
-          NumberFormat df = new DecimalFormat("0000000000".substring(0, ps2Length));
+          NumberFormat df = new DecimalFormat("0000000000".substring(0, ps2Length),
+              DecimalFormatSymbols.getInstance(Locale.ROOT));
           postcode = df.format(pc);
         } else {
           postcode = getPostCode3(bytes);
         }
-        NumberFormat threeDigits = new DecimalFormat("000");
+        NumberFormat threeDigits = new DecimalFormat("000", DecimalFormatSymbols.getInstance(Locale.ROOT));
         String country = threeDigits.format(getCountry(bytes));
         String service = threeDigits.format(getServiceClass(bytes));
         result.append(getMessage(bytes, 10, 84));
@@ -198,7 +201,7 @@ final class DecodedBitStreamParser {
             throw FormatException.getFormatInstance();
           }
           int nsval = (bytes[++i] << 24) + (bytes[++i] << 18) + (bytes[++i] << 12) + (bytes[++i] << 6) + bytes[++i];
-          sb.append(new DecimalFormat("000000000").format(nsval));
+          sb.append(new DecimalFormat("000000000", DecimalFormatSymbols.getInstance(Locale.ROOT)).format(nsval));
           break;
         case LOCK:
           shift = -1;

--- a/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/pdf417/decoder/DecodedBitStreamParser.java
@@ -23,6 +23,7 @@ import com.google.zxing.pdf417.PDF417ResultMetadata;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * <p>This class contains the methods for decoding the PDF417 codewords.</p>
@@ -194,7 +195,7 @@ final class DecodedBitStreamParser {
            codeIndex < codewords.length &&
            codewords[codeIndex] != MACRO_PDF417_TERMINATOR &&
            codewords[codeIndex] != BEGIN_MACRO_PDF417_OPTIONAL_FIELD) {
-      fileId.append(String.format("%03d", codewords[codeIndex]));
+      fileId.append(String.format(Locale.ROOT, "%03d", codewords[codeIndex]));
       codeIndex++;
     }
     if (fileId.length() == 0) {

--- a/core/src/test/java/com/google/zxing/maxicode/decoder/DecoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/maxicode/decoder/DecoderTestCase.java
@@ -19,6 +19,9 @@ package com.google.zxing.maxicode.decoder;
 import com.google.zxing.ChecksumException;
 import com.google.zxing.FormatException;
 import com.google.zxing.common.BitMatrix;
+import com.google.zxing.common.DecoderResult;
+
+import java.util.Locale;
 
 import org.junit.Test;
 import org.junit.Assert;
@@ -45,6 +48,25 @@ public final class DecoderTestCase extends Assert {
       fail("Expected FormatException");
     } catch (FormatException expected) {
       // good
+    }
+  }
+
+  @Test
+  public void testStructuredCarrierMessageLocaleIndependent() throws FormatException {
+    // Mode 2 prepends a numeric postcode, country code and service class. These must decode to
+    // Latin digits regardless of the JVM default locale (e.g. Arabic-Indic digits otherwise).
+    byte[] datawords = new byte[94];
+    Locale defaultLocale = Locale.getDefault();
+    String expected;
+    try {
+      Locale.setDefault(Locale.ENGLISH);
+      expected = DecodedBitStreamParser.decode(datawords, 2).getText();
+      Locale.setDefault(new Locale("ar", "EG"));
+      DecoderResult result = DecodedBitStreamParser.decode(datawords, 2);
+      assertEquals(expected, result.getText());
+      assertTrue(result.getText().startsWith("0"));
+    } finally {
+      Locale.setDefault(defaultLocale);
     }
   }
 

--- a/core/src/test/java/com/google/zxing/pdf417/decoder/PDF417DecoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/pdf417/decoder/PDF417DecoderTestCase.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Random;
 
 /**
@@ -60,6 +61,25 @@ public class PDF417DecoderTestCase extends Assert {
         67, optionalData[optionalData.length - 1]);
   }
 
+
+  /**
+   * The numeric file ID is built with three-digit groups; this must use Latin digits regardless of
+   * the JVM default locale.
+   */
+  @Test
+  public void testFileIdLocaleIndependent() throws FormatException {
+    int[] sampleCodes = {20, 928, 111, 100, 17, 53, 923, 1, 111, 104, 923, 3, 64, 416, 34, 923, 4, 258, 446, 67,
+      1000, 1000, 1000};
+    Locale defaultLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("ar", "EG"));
+      PDF417ResultMetadata resultMetadata = new PDF417ResultMetadata();
+      DecodedBitStreamParser.decodeMacroBlock(sampleCodes, 2, resultMetadata);
+      assertEquals("017053", resultMetadata.getFileId());
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
+  }
 
   /**
    * Tests the second given in ISO/IEC 15438:2015(E) - Annex H.4


### PR DESCRIPTION
Decoders format numeric parts of the payload with the JVM default locale, so the same symbol decodes to different text per locale (Arabic-Indic digits under ar/fa/bn):
- maxicode: postcode, country and service class (DecimalFormat) plus the NS value in getMessage
- pdf417: the Macro file id built with String.format("%03d", ...) in decodeMacroBlock
- aztec: the EC level string built with String.format("%d%%", ...)

Switched these to Locale.ROOT (and DecimalFormatSymbols.getInstance(Locale.ROOT) for DecimalFormat), matching the explicit Locale.ENGLISH already used in CalendarParsedResult. Regression tests in the maxicode and pdf417 decoder tests fail before the change under an Arabic locale.