### PR TITLE
wrap invalid base64 as IOException in readDataURIImage

### DIFF
--- a/javase/src/main/java/com/google/zxing/client/j2se/ImageReader.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/ImageReader.java
@@ -61,7 +61,12 @@ public final class ImageReader {
       throw new IOException("Unsupported data URI encoding");
     }
     String base64Data = uriString.substring(base64Start + BASE64TOKEN.length());
-    byte[] imageBytes = Base64.getDecoder().decode(base64Data);
+    byte[] imageBytes;
+    try {
+      imageBytes = Base64.getDecoder().decode(base64Data);
+    } catch (IllegalArgumentException iae) {
+      throw new IOException("Invalid base64 data URI", iae);
+    }
     return ImageIO.read(new ByteArrayInputStream(imageBytes));
   }
 

--- a/javase/src/test/java/com/google/zxing/client/j2se/ImageReaderTestCase.java
+++ b/javase/src/test/java/com/google/zxing/client/j2se/ImageReaderTestCase.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.net.URI;
 
 /**
@@ -37,5 +38,10 @@ public final class ImageReaderTestCase extends Assert {
     assertEquals(16, image.getWidth());
     assertEquals(16, image.getHeight());
   }
-  
+
+  @Test(expected = IOException.class)
+  public void testInvalidBase64DataURI() throws Exception {
+    ImageReader.readImage(new URI("data:image/png;base64,@@@notbase64@@@"));
+  }
+
 }


### PR DESCRIPTION
readDataURIImage lets Base64.getDecoder().decode throw IllegalArgumentException on a malformed data: URI, which escapes the declared IOException contract that readImage already enforces on its URL branch, so wrap the decode and rethrow it as IOException.