### PR TITLE
guard truncated structured carrier message in maxicode decode

### DIFF
--- a/core/src/main/java/com/google/zxing/maxicode/decoder/DecodedBitStreamParser.java
+++ b/core/src/main/java/com/google/zxing/maxicode/decoder/DecodedBitStreamParser.java
@@ -109,6 +109,9 @@ final class DecodedBitStreamParser {
         String service = threeDigits.format(getServiceClass(bytes));
         result.append(getMessage(bytes, 10, 84));
         if (result.toString().startsWith("[)>" + RS + "01" + GS)) {
+          if (result.length() < 9) {
+            throw FormatException.getFormatInstance();
+          }
           result.insert(9, postcode + GS + country + GS + service + GS);
         } else {
           result.insert(0, postcode + GS + country + GS + service + GS);

--- a/core/src/test/java/com/google/zxing/maxicode/decoder/DecoderTestCase.java
+++ b/core/src/test/java/com/google/zxing/maxicode/decoder/DecoderTestCase.java
@@ -71,6 +71,28 @@ public final class DecoderTestCase extends Assert {
   }
 
   @Test
+  public void testTruncatedStructuredCarrierMessageHeader() {
+    // A mode 2/3 secondary message that starts with the structured append header "[)>RS01GS"
+    // but is shorter than the 9 characters the postcode/country/service splice assumes must be
+    // rejected as a format error, not insert past the end of the buffer.
+    byte[] datawords = new byte[94];
+    // SHIFTB '[' ')' SHIFTB '>' RS '0' '1' GS -> decodes to exactly "[)>01" (7 chars)
+    int[] message = {59, 42, 41, 59, 40, 30, 48, 49, 29};
+    for (int i = 0; i < message.length; i++) {
+      datawords[10 + i] = (byte) message[i];
+    }
+    for (int i = 10 + message.length; i < datawords.length; i++) {
+      datawords[i] = 33; // PAD, trimmed off the decoded message
+    }
+    try {
+      DecodedBitStreamParser.decode(datawords, 2);
+      fail("Expected FormatException");
+    } catch (FormatException expected) {
+      // good
+    }
+  }
+
+  @Test
   public void testWrongDimensions() throws ChecksumException {
     for (int[] wh : new int[][] {{31, 33}, {30, 34}, {29, 33}, {30, 32}}) {
       try {


### PR DESCRIPTION
Mode 2/3 inserts the postcode, country and service into the decoded message at offset 9:
- the structured append header `[)>`+RS+`01`+GS is only 7 characters, so the offset is never checked against the message length
- a crafted symbol whose secondary message decodes to exactly that header (trailing PAD is trimmed off) leaves a 7-character buffer
- `insert(9, ...)` then throws StringIndexOutOfBoundsException out of `Decoder.decode`, which is declared to throw only FormatException/ChecksumException

Throw FormatException when the header is present but the message is shorter than 9.