### PR TITLE
Clear padding bits in BitMatrix.flip() so they are not read as set

### DIFF
--- a/core/src/main/java/com/google/zxing/common/BitMatrix.java
+++ b/core/src/main/java/com/google/zxing/common/BitMatrix.java
@@ -197,6 +197,15 @@ public final class BitMatrix implements Cloneable {
     for (int i = 0; i < max; i++) {
       bits[i] = ~bits[i];
     }
+    // Clear padding bits beyond the logical width in the last int of each row
+    int remainder = width % 32;
+    if (remainder != 0) {
+      int mask = (1 << remainder) - 1;
+      for (int y = 0; y < height; y++) {
+        int offset = y * rowSize + rowSize - 1;
+        bits[offset] &= mask;
+      }
+    }
   }
 
   /**

--- a/core/src/test/java/com/google/zxing/common/BitMatrixTestCase.java
+++ b/core/src/test/java/com/google/zxing/common/BitMatrixTestCase.java
@@ -343,4 +343,38 @@ public final class BitMatrixTestCase extends Assert {
     return result;
   }
 
+  @Test
+  public void testFlipDoesNotCorruptPaddingBits() {
+    // Width 5 means rowSize = 1, so last int has 27 padding bits
+    BitMatrix matrix = new BitMatrix(5, 5);
+    // Flip all bits in empty matrix
+    matrix.flip();
+
+    // All logical bits should be true
+    for (int y = 0; y < 5; y++) {
+      for (int x = 0; x < 5; x++) {
+        assertTrue("Bit (" + x + "," + y + ") should be true after flip()", matrix.get(x, y));
+      }
+    }
+
+    // getTopLeftOnBit should return (0, 0), not something beyond width due to padding bits
+    int[] topLeft = matrix.getTopLeftOnBit();
+    assertNotNull(topLeft);
+    assertArrayEquals(new int[] { 0, 0 }, topLeft);
+
+    // getBottomRightOnBit should return (4, 4), not (31, 4) or worse due to padding
+    int[] bottomRight = matrix.getBottomRightOnBit();
+    assertNotNull(bottomRight);
+    assertArrayEquals(new int[] { 4, 4 }, bottomRight);
+
+    // getEnclosingRectangle should return (0, 0, 5, 5), not (0, 0, 32, 5) due to padding
+    int[] enclosing = matrix.getEnclosingRectangle();
+    assertNotNull(enclosing);
+    assertArrayEquals(new int[] { 0, 0, 5, 5 }, enclosing);
+
+    // Double flip should restore the matrix to all-zeros, equal to a fresh matrix
+    matrix.flip();
+    assertEquals(new BitMatrix(5, 5), matrix);
+  }
+
 }


### PR DESCRIPTION
`BitMatrix.flip()` (the no-arg variant) inverts every `int` in the `bits[]` array, including the unused padding bits beyond the logical width in each row's last `int` (`rowSize = (width + 31) / 32`, so a row whose width isn't a multiple of 32 has `rowSize * 32 - width` padding bits). After `flip()`, those stray bits are set, and methods that scan the raw bits — `getTopLeftOnBit()`, `getBottomRightOnBit()`, `getEnclosingRectangle()`, `equals()` — treat them as part of the matrix.

For example, on a `5×5` matrix, `flip()` then `getBottomRightOnBit()` returns `(31, 4)` instead of `(4, 4)`.

The fix masks off the padding bits in each row's last `int` after flipping. Adds a regression test.
