### PR TITLE
reject negative and overflowing crop in BufferedImageLuminanceSource

### DIFF
--- a/javase/src/main/java/com/google/zxing/client/j2se/BufferedImageLuminanceSource.java
+++ b/javase/src/main/java/com/google/zxing/client/j2se/BufferedImageLuminanceSource.java
@@ -47,7 +47,8 @@ public final class BufferedImageLuminanceSource extends LuminanceSource {
 
     int sourceWidth = image.getWidth();
     int sourceHeight = image.getHeight();
-    if (left + width > sourceWidth || top + height > sourceHeight) {
+    if (left < 0 || top < 0 || width < 0 || height < 0 ||
+        width > sourceWidth - left || height > sourceHeight - top) {
       throw new IllegalArgumentException("Crop rectangle does not fit within image data.");
     }
 

--- a/javase/src/test/java/com/google/zxing/client/j2se/BufferedImageLuminanceSourceTest.java
+++ b/javase/src/test/java/com/google/zxing/client/j2se/BufferedImageLuminanceSourceTest.java
@@ -51,6 +51,34 @@ public final class BufferedImageLuminanceSourceTest extends Assert {
   }
 
   @Test
+  public void testNegativeOffsetOnGrayImage() {
+    BufferedImage grayImage = new BufferedImage(10, 10, BufferedImage.TYPE_BYTE_GRAY);
+    Assert.assertThrows(IllegalArgumentException.class, () ->
+        new BufferedImageLuminanceSource(grayImage, -1, 0, 5, 5)
+    );
+    Assert.assertThrows(IllegalArgumentException.class, () ->
+        new BufferedImageLuminanceSource(grayImage, 0, -1, 5, 5)
+    );
+  }
+
+  @Test
+  public void testNegativeOffsetOnColorImage() {
+    BufferedImage colorImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+    Assert.assertThrows(IllegalArgumentException.class, () ->
+        new BufferedImageLuminanceSource(colorImage, -1, 0, 5, 5)
+    );
+  }
+
+  @Test
+  public void testCropOffsetOverflowOnGrayImage() {
+    BufferedImage grayImage = new BufferedImage(10, 10, BufferedImage.TYPE_BYTE_GRAY);
+    // left + width overflows int and wraps negative, so an upper-bound-only check passes
+    Assert.assertThrows(IllegalArgumentException.class, () ->
+        new BufferedImageLuminanceSource(grayImage, Integer.MAX_VALUE, 0, 10, 5)
+    );
+  }
+
+  @Test
   public void testValidCropRectangleOnGrayImage() {
     BufferedImage grayImage = new BufferedImage(10, 10, BufferedImage.TYPE_BYTE_GRAY);
     


### PR DESCRIPTION
The crop bounds check added in #2107 still lets two invalid-input cases through:
- negative left/top/width/height aren't rejected
- left + width and top + height overflow int, so an offset near Integer.MAX_VALUE passes the upper-bound test
For TYPE_BYTE_GRAY images the source image is kept by reference, so a bad crop surfaces later as an ArrayIndexOutOfBoundsException from getRow/getMatrix; other image types throw it from getRGB, neither matching the documented IllegalArgumentException. The four --crop values from the javase CLI flow straight into this constructor. Reject the negative offsets and compare against sourceWidth - left / sourceHeight - top so every invalid crop fails fast.
