### PR TITLE
reject negative and overflowing crop in core LuminanceSource classes

### DIFF
--- a/core/src/main/java/com/google/zxing/GrayscaleLuminanceSource.java
+++ b/core/src/main/java/com/google/zxing/GrayscaleLuminanceSource.java
@@ -48,7 +48,8 @@ public class GrayscaleLuminanceSource extends LuminanceSource {
                                    int width,
                                    int height) {
     super(width, height);
-    if (left + width > dataWidth || top + height > dataHeight) {
+    if (left < 0 || top < 0 || width < 0 || height < 0 ||
+        width > dataWidth - left || height > dataHeight - top) {
       throw new IllegalArgumentException("Crop rectangle does not fit within image data.");
     }
     this.luminances = pixels;

--- a/core/src/main/java/com/google/zxing/PlanarYUVLuminanceSource.java
+++ b/core/src/main/java/com/google/zxing/PlanarYUVLuminanceSource.java
@@ -46,7 +46,8 @@ public final class PlanarYUVLuminanceSource extends LuminanceSource {
                                   boolean reverseHorizontal) {
     super(width, height);
 
-    if (left + width > dataWidth || top + height > dataHeight) {
+    if (left < 0 || top < 0 || width < 0 || height < 0 ||
+        width > dataWidth - left || height > dataHeight - top) {
       throw new IllegalArgumentException("Crop rectangle does not fit within image data.");
     }
 

--- a/core/src/test/java/com/google/zxing/GrayscaleLuminanceSourceTestCase.java
+++ b/core/src/test/java/com/google/zxing/GrayscaleLuminanceSourceTestCase.java
@@ -109,6 +109,16 @@ public final class GrayscaleLuminanceSourceTestCase extends Assert {
   }
 
   @Test(expected = IllegalArgumentException.class)
+  public void testNegativeCrop() {
+    SOURCE.crop(-1, 0, 3, 3);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOverflowCrop() {
+    SOURCE.crop(1, 0, Integer.MAX_VALUE, 3);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
   public void testNullPixelArray() {
     // Test regression: null pixel array should throw IllegalArgumentException
     new RGBLuminanceSource(3, 3, null);

--- a/core/src/test/java/com/google/zxing/PlanarYUVLuminanceSourceTestCase.java
+++ b/core/src/test/java/com/google/zxing/PlanarYUVLuminanceSourceTestCase.java
@@ -72,6 +72,16 @@ public final class PlanarYUVLuminanceSourceTestCase extends Assert {
         source.renderThumbnail());
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testNegativeCrop() {
+    new PlanarYUVLuminanceSource(YUV, COLS, ROWS, -1, 0, COLS, ROWS, false);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOverflowCrop() {
+    new PlanarYUVLuminanceSource(YUV, COLS, ROWS, 1, 0, Integer.MAX_VALUE, ROWS, false);
+  }
+
   private static void assertEquals(byte[] expected, int expectedFrom,
                                    byte[] actual, int actualFrom,
                                    int length) {


### PR DESCRIPTION
the crop constructors in PlanarYUVLuminanceSource and GrayscaleLuminanceSource did not reject negative offsets or sizes and overflowed when checking left+width and top+height, letting an out-of-bounds crop reach getRow and getMatrix; validate the rectangle the same way as BufferedImageLuminanceSource.