### PR TITLE
reject non-positive datablock count in aztec correctBits

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -302,7 +302,7 @@ public final class Decoder {
 
     int numDataCodewords = ddata.getNbDatablocks();
     int numCodewords = rawbits.length / codewordSize;
-    if (numCodewords < numDataCodewords) {
+    if (numDataCodewords < 1 || numCodewords < numDataCodewords) {
       throw FormatException.getFormatInstance();
     }
     int offset = rawbits.length % codewordSize;

--- a/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
@@ -71,6 +71,25 @@ public final class DecoderTest extends Assert {
   }
 
   @Test
+  public void testDecodeNoDataCodewords() {
+    // a detector result claiming zero (or negative) data codewords must fail as FormatException,
+    // not IllegalArgumentException / NegativeArraySizeException out of the Reed-Solomon step
+    BitMatrix matrix = new BitMatrix(151, 151);
+    for (int nbDatablocks : new int[] { 0, -1 }) {
+      for (int nbLayers : new int[] { 0, 1, 2 }) {
+        for (boolean compact : new boolean[] { true, false }) {
+          try {
+            new Decoder().decode(new AztecDetectorResult(matrix, NO_POINTS, compact, nbDatablocks, nbLayers));
+            fail("nbDatablocks=" + nbDatablocks + " nbLayers=" + nbLayers + " should be rejected");
+          } catch (FormatException expected) {
+            // expected
+          }
+        }
+      }
+    }
+  }
+
+  @Test
   public void testAztecResult() throws FormatException {
     BitMatrix matrix = BitMatrix.parse(
         "X X X X X     X X X       X X X     X X X     \n" +


### PR DESCRIPTION
correctBits never rejects a non-positive datablock count from the detector result:
- nbDatablocks 0: the Reed-Solomon step builds an empty GenericGFPoly and throws IllegalArgumentException
- nbDatablocks negative: `new boolean[numDataCodewords * codewordSize - stuffedBits]` throws NegativeArraySizeException
- both escape Decoder.decode(AztecDetectorResult), which is documented to throw only FormatException

reject numDataCodewords < 1 at the existing check; the image path is unaffected since the detector always sets it >= 1.