### PR TITLE
reject bit matrix not matching layer count in aztec extractBits

### DIFF
--- a/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
+++ b/core/src/main/java/com/google/zxing/aztec/decoder/Decoder.java
@@ -357,10 +357,16 @@ public final class Decoder {
    *
    * @return the array of bits
    */
-  private boolean[] extractBits(BitMatrix matrix) {
+  private boolean[] extractBits(BitMatrix matrix) throws FormatException {
     boolean compact = ddata.isCompact();
     int layers = ddata.getNbLayers();
     int baseMatrixSize = (compact ? 11 : 14) + layers * 4; // not including alignment lines
+    int matrixSize = compact ? baseMatrixSize : baseMatrixSize + 1 + 2 * ((baseMatrixSize / 2 - 1) / 15);
+    if (matrix.getHeight() != matrixSize || matrix.getWidth() != matrixSize) {
+      // The matrix dimensions are fixed by the layer count; a mismatched detector result would
+      // otherwise index outside the matrix below.
+      throw FormatException.getFormatInstance();
+    }
     int[] alignmentMap = new int[baseMatrixSize];
     boolean[] rawbits = new boolean[totalBitsInLayer(layers, compact)];
 
@@ -369,7 +375,6 @@ public final class Decoder {
         alignmentMap[i] = i;
       }
     } else {
-      int matrixSize = baseMatrixSize + 1 + 2 * ((baseMatrixSize / 2 - 1) / 15);
       int origCenter = baseMatrixSize / 2;
       int center = matrixSize / 2;
       for (int i = 0; i < origCenter; i++) {

--- a/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
+++ b/core/src/test/java/com/google/zxing/aztec/decoder/DecoderTest.java
@@ -90,6 +90,23 @@ public final class DecoderTest extends Assert {
   }
 
   @Test
+  public void testDecodeLayerCountMatrixMismatch() {
+    // a detector result whose bit matrix is smaller than its layer count implies must fail as
+    // FormatException, not ArrayIndexOutOfBoundsException out of the bit-extraction step
+    BitMatrix matrix = new BitMatrix(15, 15); // the size of a compact one-layer symbol only
+    for (boolean compact : new boolean[] { true, false }) {
+      for (int nbLayers : new int[] { 2, 4, 10, 32 }) {
+        try {
+          new Decoder().decode(new AztecDetectorResult(matrix, NO_POINTS, compact, 10, nbLayers));
+          fail("compact=" + compact + " nbLayers=" + nbLayers + " should be rejected");
+        } catch (FormatException expected) {
+          // expected
+        }
+      }
+    }
+  }
+
+  @Test
   public void testAztecResult() throws FormatException {
     BitMatrix matrix = BitMatrix.parse(
         "X X X X X     X X X       X X X     X X X     \n" +


### PR DESCRIPTION
aztec extractBits reads the bit matrix at coordinates derived from the layer count without first checking the matrix is that size:
- a detector result whose nbLayers implies a bigger matrix reaches matrix.get() past the end, throwing ArrayIndexOutOfBoundsException out of decode, which is documented to throw only FormatException
- the detector always sizes the matrix to the layer count, so scanned images are unaffected; only a caller-built AztecDetectorResult hits it
- reject the mismatch before the read, matching the dimension checks in the qrcode and datamatrix bit matrix parsers
